### PR TITLE
[#275] 정산 계산기 균등분배 최적화

### DIFF
--- a/engines/settlement/app/services/settlement/calculator.rb
+++ b/engines/settlement/app/services/settlement/calculator.rb
@@ -79,6 +79,50 @@ module Settlement
 
       @per_member_totals = totals.sort_by { |_member, amount| -amount }.to_h
       @computed = true
+
+      equalize_if_possible
+    end
+
+    # 총액이 인원수로 깔끔하게 나눠지고, 차이가 반올림에서만 기인하면 균등 금액으로 대체
+    def equalize_if_possible
+      members = @per_member_totals.keys
+      return if members.empty?
+
+      total = total_amount
+      count = members.size
+      return unless evenly_divisible?(total, count)
+
+      even_amount = total / count
+      total_extras = @rounding_extras.values.sum
+      return unless @per_member_totals.all? { |_, amt| (amt - even_amount).abs <= total_extras }
+
+      @per_member_totals = members.map { |m| [m, even_amount] }.to_h
+      @rounding_extras = Hash.new(0)
+      @item_remainder_assignees = {}
+
+      equalize_rounds
+    end
+
+    # 각 라운드별 독립적으로 균등분배 판단 및 적용
+    def equalize_rounds
+      @round_details.each do |detail|
+        round_members = detail[:member_amounts].keys
+        next if round_members.empty?
+
+        round_total = detail[:total]
+        round_count = round_members.size
+        next unless evenly_divisible?(round_total, round_count)
+
+        even_amount = round_total / round_count
+        max_diff = detail[:member_amounts].values.max - detail[:member_amounts].values.min
+        next unless detail[:member_amounts].all? { |_, amt| (amt - even_amount).abs <= max_diff }
+
+        detail[:member_amounts] = round_members.map { |m| [m, even_amount] }.to_h
+      end
+    end
+
+    def evenly_divisible?(amount, count)
+      count > 0 && amount % count == 0 && (amount / count) % ROUNDING_UNIT == 0
     end
 
     def loaded_rounds

--- a/engines/settlement/app/services/settlement/calculator.rb
+++ b/engines/settlement/app/services/settlement/calculator.rb
@@ -96,7 +96,7 @@ module Settlement
       total_extras = @rounding_extras.values.sum
       return unless @per_member_totals.all? { |_, amt| (amt - even_amount).abs <= total_extras }
 
-      @per_member_totals = members.map { |m| [m, even_amount] }.to_h
+      @per_member_totals = members.map { |m| [ m, even_amount ] }.to_h
       @rounding_extras = Hash.new(0)
       @item_remainder_assignees = {}
 
@@ -117,7 +117,7 @@ module Settlement
         max_diff = detail[:member_amounts].values.max - detail[:member_amounts].values.min
         next unless detail[:member_amounts].all? { |_, amt| (amt - even_amount).abs <= max_diff }
 
-        detail[:member_amounts] = round_members.map { |m| [m, even_amount] }.to_h
+        detail[:member_amounts] = round_members.map { |m| [ m, even_amount ] }.to_h
       end
     end
 

--- a/engines/settlement/app/services/settlement/calculator.rb
+++ b/engines/settlement/app/services/settlement/calculator.rb
@@ -91,6 +91,7 @@ module Settlement
       total = total_amount
       count = members.size
       return unless evenly_divisible?(total, count)
+      return if has_tagged_items?
 
       even_amount = total / count
       total_extras = @rounding_extras.values.sum
@@ -112,13 +113,17 @@ module Settlement
         round_total = detail[:total]
         round_count = round_members.size
         next unless evenly_divisible?(round_total, round_count)
+        next if detail[:round].items.any? { |i| !i.is_shared && i.item_members.any? }
 
         even_amount = round_total / round_count
-        max_diff = detail[:member_amounts].values.max - detail[:member_amounts].values.min
-        next unless detail[:member_amounts].all? { |_, amt| (amt - even_amount).abs <= max_diff }
 
         detail[:member_amounts] = round_members.map { |m| [ m, even_amount ] }.to_h
       end
+    end
+
+    # 특정 멤버만 참여하는 태그 항목이 존재하는지 확인
+    def has_tagged_items?
+      loaded_rounds.any? { |r| r.items.any? { |i| !i.is_shared && i.item_members.any? } }
     end
 
     def evenly_divisible?(amount, count)

--- a/test/services/settlement/calculator_test.rb
+++ b/test/services/settlement/calculator_test.rb
@@ -153,4 +153,46 @@ class Settlement::CalculatorTest < ActiveSupport::TestCase
 
     assert_equal 0, extras.values.sum
   end
+
+  test "항목별 반올림 누적되어도 총액이 균등분배 가능하면 균등 금액으로 대체" do
+    round = @gathering.rounds.create!(name: "1차")
+    round.items.create!(name: "항목1", quantity: 1, amount: 31000)
+    round.items.create!(name: "항목2", quantity: 1, amount: 32000)
+    # 총 63,000 / 3 = 21,000 (균등분배 가능)
+
+    calculator = Settlement::Calculator.new(@gathering)
+    totals = calculator.per_member_totals
+
+    assert_equal 21000, totals[@member1]
+    assert_equal 21000, totals[@member2]
+    assert_equal 21000, totals[@member3]
+    assert_equal 0, calculator.rounding_extras.values.sum
+    assert_empty calculator.item_remainder_assignees
+  end
+
+  test "균등분배 시 라운드 레벨에서도 균등 금액 적용" do
+    round = @gathering.rounds.create!(name: "1차")
+    round.items.create!(name: "항목1", quantity: 1, amount: 25000, is_shared: true)
+    round.items.create!(name: "항목2", quantity: 1, amount: 2000, is_shared: true)
+    # 총 27,000 / 3 = 9,000
+
+    calculator = Settlement::Calculator.new(@gathering)
+    detail = calculator.round_details.first
+
+    assert_equal 9000, detail[:member_amounts].values.uniq.first
+    assert_equal 1, detail[:member_amounts].values.uniq.size
+  end
+
+  test "특정 멤버만 참여하는 항목이 있으면 균등분배 미적용" do
+    round = @gathering.rounds.create!(name: "1차")
+    round.items.create!(name: "공통", quantity: 1, amount: 30000, is_shared: true)
+    item = round.items.create!(name: "소주", quantity: 1, amount: 10000)
+    item.item_members.create!(member: @member1)
+    item.item_members.create!(member: @member2)
+
+    calculator = Settlement::Calculator.new(@gathering)
+    totals = calculator.per_member_totals
+
+    assert_operator totals.values.max - totals.values.min, :>, 0
+  end
 end

--- a/test/services/settlement/calculator_test.rb
+++ b/test/services/settlement/calculator_test.rb
@@ -195,4 +195,18 @@ class Settlement::CalculatorTest < ActiveSupport::TestCase
 
     assert_operator totals.values.max - totals.values.min, :>, 0
   end
+
+  test "태그 항목 있고 반올림 차이 범위 내여도 균등분배 미적용" do
+    round = @gathering.rounds.create!(name: "1차")
+    round.items.create!(name: "공통", quantity: 1, amount: 29970, is_shared: true)
+    item = round.items.create!(name: "소주", quantity: 1, amount: 30)
+    item.item_members.create!(member: @member1)
+    item.item_members.create!(member: @member2)
+    # 총 30,000 / 3 = 10,000 (균등분배 가능하지만 태그 항목이 있으므로 미적용)
+
+    calculator = Settlement::Calculator.new(@gathering)
+    totals = calculator.per_member_totals
+
+    assert_operator totals.values.max - totals.values.min, :>, 0
+  end
 end


### PR DESCRIPTION
# 📝 변경사항

## 🔄 포함된 커밋

- feat: [#275] 정산 계산기 균등분배 최적화 (Joungsik, 19 hours ago)
- fix: 배열 괄호 안 스페이스 lint 오류 수정 (Joungsik, 19 hours ago)
- fix: [#275] 균등분배 태그 항목 체크 누락 및 tautology 조건 수정 (Joungsik, 12 seconds ago)

## 📊 요약
- 총 3개의 커밋
- 기본 브랜치: `main`
- 작업 브랜치: `fix/settlement-equal-split`

## 📁 변경된 파일

- engines/settlement/app/services/settlement/calculator.rb
- test/services/settlement/calculator_test.rb

---
🤖 이 PR은 GitHub Actions에 의해 자동으로 생성되었습니다.
