### PR TITLE
chore: Dependabot staging 브랜치 설정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: bundler
     directory: "/"
+    target-branch: deps/staging
     schedule:
       interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: deps/staging
     schedule:
       interval: daily
     open-pull-requests-limit: 10


### PR DESCRIPTION
# 📝 변경사항

## 🔄 포함된 커밋

- chore: Dependabot staging 브랜치 설정 (Joungsik, 43 seconds ago)

## 📊 요약
- 총 1개의 커밋
- 기본 브랜치: `main`
- 작업 브랜치: `chore/dependabot-staging`

## 📁 변경된 파일

- .github/dependabot.yml

---
🤖 이 PR은 GitHub Actions에 의해 자동으로 생성되었습니다.
