### PR TITLE
feat: 할 일 목록 보관 탭 분리

### DIFF
--- a/engines/todo/app/controllers/todo/lists_controller.rb
+++ b/engines/todo/app/controllers/todo/lists_controller.rb
@@ -3,7 +3,9 @@ module Todo
     before_action :set_list, only: %i[show edit update destroy]
 
     def index
-      @lists = List.by_user(current_user_id).order(id: :desc)
+      @current_tab = params[:tab] == "archived" ? :archived : :active
+      user_lists = List.by_user(current_user_id)
+      @lists = (@current_tab == :archived ? user_lists.archived : user_lists.active).order(id: :desc)
     end
 
     def show

--- a/engines/todo/app/views/todo/lists/index.html.erb
+++ b/engines/todo/app/views/todo/lists/index.html.erb
@@ -7,6 +7,21 @@
     <% end %>
   </div>
 
+  <nav class="mb-6 border-b border-gray-200 dark:border-gray-700" role="tablist" aria-label="할 일 목록 구분">
+    <div class="flex gap-6">
+      <%= link_to "일반",
+                  todo.lists_path,
+                  role: "tab",
+                  aria: { selected: @current_tab == :active },
+                  class: "border-b-2 px-1 pb-3 text-sm font-medium transition-colors duration-200 #{@current_tab == :active ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-200'}" %>
+      <%= link_to "보관됨",
+                  todo.lists_path(tab: :archived),
+                  role: "tab",
+                  aria: { selected: @current_tab == :archived },
+                  class: "border-b-2 px-1 pb-3 text-sm font-medium transition-colors duration-200 #{@current_tab == :archived ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-200'}" %>
+    </div>
+  </nav>
+
   <div id="lists">
     <% if @lists.any? %>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 lg:gap-6">
@@ -23,8 +38,13 @@
         <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
-        <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">할 일 목록이 없습니다</h3>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">첫 번째 할 일 목록을 만들어보세요.</p>
+        <% if @current_tab == :archived %>
+          <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">보관된 목록이 없습니다</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">보관한 할 일 목록이 여기에 표시됩니다.</p>
+        <% else %>
+          <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">할 일 목록이 없습니다</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">첫 번째 할 일 목록을 만들어보세요.</p>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/test/integration/todo/lists_test.rb
+++ b/test/integration/todo/lists_test.rb
@@ -13,6 +13,26 @@ class Todo::ListsTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "일반 탭에는 보관하지 않은 목록만 표시한다" do
+    archived_list = Todo::List.create!(title: "보관된 목록", user_id: @user.id, archived_at: Time.current)
+
+    get todo.lists_url
+
+    assert_select "a[role='tab'][aria-selected='true']", text: "일반"
+    assert_select "#lists h3", text: @list.title
+    assert_select "#lists h3", text: archived_list.title, count: 0
+  end
+
+  test "보관됨 탭에는 보관한 목록만 표시한다" do
+    archived_list = Todo::List.create!(title: "보관된 목록", user_id: @user.id, archived_at: Time.current)
+
+    get todo.lists_url(tab: :archived)
+
+    assert_select "a[role='tab'][aria-selected='true']", text: "보관됨"
+    assert_select "#lists h3", text: archived_list.title
+    assert_select "#lists h3", text: @list.title, count: 0
+  end
+
   test "목록 상세에 접근할 수 있다" do
     get todo.list_url(@list)
     assert_response :success


### PR DESCRIPTION
# 📝 변경사항

## 🔄 포함된 커밋

- feat: 할 일 목록 보관 탭 분리 (Joungsik, 52 seconds ago)

## 📊 요약
- 총 1개의 커밋
- 기본 브랜치: `main`
- 작업 브랜치: `develop`

## 📁 변경된 파일

- engines/todo/app/controllers/todo/lists_controller.rb
- engines/todo/app/views/todo/lists/index.html.erb
- test/integration/todo/lists_test.rb

---
🤖 이 PR은 GitHub Actions에 의해 자동으로 생성되었습니다.
