### PR TITLE
[#351] 포스트 엔진 데스크톱 레이아웃 개선

### DIFF
--- a/engines/journal/app/views/journal/posts/edit.html.erb
+++ b/engines/journal/app/views/journal/posts/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full max-w-2xl mx-auto">
+<div class="w-full">
   <div class="mb-6">
     <%= link_to posts.post_path(@post), class: "inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors duration-200" do %>
       <%= lucide_icon "arrow-left", class: "w-4 h-4" %>

--- a/engines/journal/app/views/journal/posts/index.html.erb
+++ b/engines/journal/app/views/journal/posts/index.html.erb
@@ -1,21 +1,23 @@
-<div class="w-full max-w-2xl mx-auto">
+<div id="posts-page" class="w-full">
   <div class="flex items-center justify-between gap-3 mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">포스트</h1>
   </div>
 
-  <section class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-4 sm:p-5 mb-6">
-    <%= render "form", post: @post %>
-  </section>
+  <div class="lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:gap-8">
+    <section id="post-composer" class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm p-4 sm:p-5 mb-6 lg:sticky lg:top-8 lg:self-start lg:mb-0">
+      <%= render "form", post: @post %>
+    </section>
 
-  <div id="posts" class="space-y-3">
-    <% if @posts.any? %>
-      <%= render @posts %>
-    <% else %>
-      <div class="text-center py-12">
-        <%= lucide_icon "message-square", class: "mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" %>
-        <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">포스트가 없습니다</h3>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">첫 번째 포스트를 남겨보세요.</p>
-      </div>
-    <% end %>
+    <div id="posts" class="space-y-3">
+      <% if @posts.any? %>
+        <%= render @posts %>
+      <% else %>
+        <div class="text-center py-12">
+          <%= lucide_icon "message-square", class: "mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" %>
+          <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">포스트가 없습니다</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">첫 번째 포스트를 남겨보세요.</p>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/engines/journal/app/views/journal/posts/show.html.erb
+++ b/engines/journal/app/views/journal/posts/show.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full max-w-2xl mx-auto">
+<div class="w-full">
   <div class="mb-6">
     <%= link_to posts.root_path, class: "inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors duration-200" do %>
       <%= lucide_icon "arrow-left", class: "w-4 h-4" %>

--- a/test/system/journal_posts_layout_test.rb
+++ b/test/system/journal_posts_layout_test.rb
@@ -1,0 +1,62 @@
+require "application_system_test_case"
+
+class JournalPostsLayoutTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:test_user)
+    Journal::Post.create!(body: "레이아웃 확인용 포스트", user_id: @user.id)
+    sign_in_as @user
+  end
+
+  teardown do
+    resize_browser_to(1400, 1400)
+  end
+
+  test "데스크톱에서는 작성 영역과 피드가 나란히 표시된다" do
+    resize_browser_to(1920, 1000)
+    visit posts.root_url
+
+    page_container, composer, feed, main_content_width = post_layout_positions
+
+    assert_in_delta main_content_width, page_container["width"], 1
+    assert_in_delta composer["width"] * 2, feed["width"], 1
+    assert_operator feed["left"] - composer["right"], :>=, 32
+    assert_in_delta composer["top"], feed["top"], 1
+  end
+
+  test "모바일에서는 작성 영역 뒤에 피드가 표시된다" do
+    resize_browser_to(390, 844)
+    visit posts.root_url
+
+    _page_container, composer, feed, _main_content_width = post_layout_positions
+
+    assert_operator feed["top"], :>, composer["bottom"]
+    assert_in_delta composer["left"], feed["left"], 1
+  end
+
+  private
+
+  def resize_browser_to(width, height)
+    page.driver.browser.manage.window.resize_to(width, height)
+  end
+
+  def post_layout_positions
+    layout = page.evaluate_script(<<~JS)
+      (() => {
+        const pageContainer = document.querySelector("#posts-page").getBoundingClientRect();
+        const main = document.querySelector("main");
+        const mainStyles = window.getComputedStyle(main);
+        const composer = document.querySelector("#post-composer").getBoundingClientRect();
+        const feed = document.querySelector("#posts").getBoundingClientRect();
+
+        return {
+          pageContainer: { width: pageContainer.width },
+          composer: { left: composer.left, right: composer.right, top: composer.top, bottom: composer.bottom, width: composer.width },
+          feed: { left: feed.left, top: feed.top, width: feed.width },
+          mainContentWidth: main.clientWidth - parseFloat(mainStyles.paddingLeft) - parseFloat(mainStyles.paddingRight)
+        };
+      })()
+    JS
+
+    [ layout["pageContainer"], layout["composer"], layout["feed"], layout["mainContentWidth"] ]
+  end
+end


### PR DESCRIPTION
## 변경 사항
포스트 목록을 전체 가용 폭의 데스크톱 1:2 작성·피드 레이아웃으로 변경하고, 작성 패널을 고정했습니다.
포스트 상세·수정 화면도 전체 가용 폭을 사용하도록 통일했습니다.

## 검증
Running 14 tests in a single process (parallelization threshold is 50)
Run options: --seed 60805

# Running:

Capybara starting Puma...
* Version 8.0.2, codename: Into the Arena
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:60801
..............

Finished in 5.129811s, 2.7291 runs/s, 8.3824 assertions/s.
14 runs, 43 assertions, 0 failures, 0 errors, 0 skips