### PR TITLE
chore: 테스트 미커버 영역 보강

### DIFF
--- a/test/helpers/navigation_helper_test.rb
+++ b/test/helpers/navigation_helper_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+class NavigationHelperTest < ActiveSupport::TestCase
+  include NavigationHelper
+
+  attr_accessor :authenticated_flag, :stub_user, :stub_path
+
+  setup do
+    @authenticated_flag = false
+    @stub_user = nil
+    @stub_path = "/"
+  end
+
+  test "비인증 상태에서는 홈과 로그인 항목만 구성한다" do
+    self.authenticated_flag = false
+
+    items = navigation_items
+
+    assert_equal 2, items.size
+    assert_equal main_app.root_path, items.first[:path]
+    assert_equal main_app.new_session_path, items.last[:path]
+  end
+
+  test "인증 상태에서는 홈으로 시작하고 마이페이지로 끝난다" do
+    self.authenticated_flag = true
+    self.stub_user = user_double([])
+
+    items = navigation_items
+
+    assert_equal main_app.root_path, items.first[:path]
+    assert_equal main_app.mypage_user_path, items.last[:path]
+    assert_not_includes items.map { |item| item[:path] }, main_app.new_session_path
+  end
+
+  test "인증 상태에서 활성 플러그인이 홈과 마이페이지 사이에 추가된다" do
+    self.authenticated_flag = true
+    plugin = Struct.new(:label, :path, :icon).new("할 일", "/todos", "check")
+    self.stub_user = user_double([ plugin ])
+
+    paths = navigation_items.map { |item| item[:path] }
+
+    assert_equal [ main_app.root_path, "/todos", main_app.mypage_user_path ], paths
+  end
+
+  test "루트 경로 항목은 현재 경로가 정확히 일치할 때만 활성이다" do
+    home = navigation_items.first
+
+    self.stub_path = "/"
+    assert navigation_item_active?(home)
+
+    self.stub_path = "/todos"
+    assert_not navigation_item_active?(home)
+  end
+
+  test "일반 항목은 현재 경로가 active_paths로 시작하면 활성이다" do
+    item = { path: "/mypage/user", active_paths: [ "/mypage/user" ] }
+
+    self.stub_path = "/mypage/user/edit"
+    assert navigation_item_active?(item)
+
+    self.stub_path = "/todos"
+    assert_not navigation_item_active?(item)
+  end
+
+  private
+
+  def authenticated?
+    authenticated_flag
+  end
+
+  def current_user
+    stub_user
+  end
+
+  def request
+    Struct.new(:path).new(stub_path)
+  end
+
+  def main_app
+    @main_app ||= Class.new do
+      include Rails.application.routes.url_helpers
+
+      def default_url_options
+        {}
+      end
+    end.new
+  end
+
+  def t(key)
+    key
+  end
+
+  def user_double(plugins)
+    Struct.new(:enabled_plugins).new(plugins)
+  end
+end

--- a/test/models/push_subscription_test.rb
+++ b/test/models/push_subscription_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+class PushSubscriptionTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:test_user)
+    @subscription = PushSubscription.create!(
+      user: @user,
+      endpoint: "https://push.example.com/abc",
+      p256dh_key: "p256dh-key",
+      auth_key: "auth-key"
+    )
+  end
+
+  test "endpoint가 없으면 유효하지 않다" do
+    subscription = PushSubscription.new(user: @user, p256dh_key: "k", auth_key: "a")
+    assert_not subscription.valid?
+  end
+
+  test "endpoint는 유일해야 한다" do
+    duplicate = PushSubscription.new(
+      user: @user,
+      endpoint: @subscription.endpoint,
+      p256dh_key: "other-key",
+      auth_key: "other-auth"
+    )
+    assert_not duplicate.valid?
+  end
+
+  test "p256dh_key가 없으면 유효하지 않다" do
+    subscription = PushSubscription.new(user: @user, endpoint: "https://push.example.com/x", auth_key: "a")
+    assert_not subscription.valid?
+  end
+
+  test "auth_key가 없으면 유효하지 않다" do
+    subscription = PushSubscription.new(user: @user, endpoint: "https://push.example.com/x", p256dh_key: "k")
+    assert_not subscription.valid?
+  end
+
+  test "user가 없으면 유효하지 않다" do
+    subscription = PushSubscription.new(endpoint: "https://push.example.com/x", p256dh_key: "k", auth_key: "a")
+    assert_not subscription.valid?
+  end
+
+  test "send_notification 성공 시 레코드를 유지하고 결과를 반환한다" do
+    stub_web_push(result: true) do
+      assert_no_difference "PushSubscription.count" do
+        assert @subscription.send_notification(title: "제목", body: "내용")
+      end
+    end
+  end
+
+  test "만료된 구독은 삭제하고 false를 반환한다" do
+    stub_web_push(error: WebPush::ExpiredSubscription.new(response_double, "example.com")) do
+      assert_difference "PushSubscription.count", -1 do
+        assert_not @subscription.send_notification(title: "제목", body: "내용")
+      end
+    end
+  end
+
+  test "무효한 구독은 삭제하고 false를 반환한다" do
+    stub_web_push(error: WebPush::InvalidSubscription.new(response_double, "example.com")) do
+      assert_difference "PushSubscription.count", -1 do
+        assert_not @subscription.send_notification(title: "제목", body: "내용")
+      end
+    end
+  end
+
+  test "기타 WebPush 오류는 레코드를 유지하고 false를 반환한다" do
+    stub_web_push(error: WebPush::PushServiceError.new(response_double, "example.com")) do
+      assert_no_difference "PushSubscription.count" do
+        assert_not @subscription.send_notification(title: "제목", body: "내용")
+      end
+    end
+  end
+
+  private
+
+  def response_double
+    Struct.new(:body).new("error body")
+  end
+
+  def stub_web_push(result: nil, error: nil)
+    original = WebPush.method(:payload_send)
+    WebPush.define_singleton_method(:payload_send) do |**|
+      raise error if error
+      result
+    end
+    yield
+  ensure
+    WebPush.define_singleton_method(:payload_send, original)
+  end
+end

--- a/test/models/todo/list_test.rb
+++ b/test/models/todo/list_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+
+class Todo::ListTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:test_user)
+    @other_user = users(:other_user)
+  end
+
+  test "active 스코프는 보관되지 않은 리스트만 반환한다" do
+    active = Todo::List.create!(title: "활성", user_id: @user.id)
+    archived = Todo::List.create!(title: "보관", user_id: @user.id, archived_at: Time.current)
+
+    result = Todo::List.by_user(@user.id).active
+    assert_includes result, active
+    assert_not_includes result, archived
+  end
+
+  test "archived 스코프는 보관된 리스트만 반환한다" do
+    active = Todo::List.create!(title: "활성", user_id: @user.id)
+    archived = Todo::List.create!(title: "보관", user_id: @user.id, archived_at: Time.current)
+
+    result = Todo::List.by_user(@user.id).archived
+    assert_includes result, archived
+    assert_not_includes result, active
+  end
+
+  test "by_user 스코프는 해당 유저의 리스트만 반환한다" do
+    mine = Todo::List.create!(title: "내 것", user_id: @user.id)
+    theirs = Todo::List.create!(title: "타인 것", user_id: @other_user.id)
+
+    result = Todo::List.by_user(@user.id)
+    assert_includes result, mine
+    assert_not_includes result, theirs
+  end
+
+  test "archived_at이 있으면 archived?는 true" do
+    list = Todo::List.new(title: "리스트", user_id: @user.id, archived_at: Time.current)
+    assert list.archived?
+  end
+
+  test "archived_at이 없으면 archived?는 false" do
+    list = Todo::List.new(title: "리스트", user_id: @user.id)
+    assert_not list.archived?
+  end
+
+  test "archive!는 archived_at을 설정한다" do
+    list = Todo::List.create!(title: "리스트", user_id: @user.id)
+    assert_not list.archived?
+
+    list.archive!
+
+    assert list.archived?
+    assert_not_nil list.archived_at
+  end
+
+  test "unarchive!는 archived_at을 해제한다" do
+    list = Todo::List.create!(title: "리스트", user_id: @user.id, archived_at: Time.current)
+    assert list.archived?
+
+    list.unarchive!
+
+    assert_not list.archived?
+    assert_nil list.archived_at
+  end
+
+  test "sorted_items는 미완료를 먼저, 마감일 오름차순으로 정렬한다" do
+    list = Todo::List.create!(title: "리스트", user_id: @user.id)
+    later = list.items.create!(title: "미완료 늦은 마감", completed: false, due_date: Date.new(2026, 3, 5))
+    earlier = list.items.create!(title: "미완료 이른 마감", completed: false, due_date: Date.new(2026, 3, 1))
+    done = list.items.create!(title: "완료", completed: true, due_date: Date.new(2026, 3, 1))
+
+    assert_equal [ earlier.id, later.id, done.id ], list.sorted_items.map(&:id)
+  end
+
+  test "sorted_items는 동일 조건에서 생성일 최신순으로 정렬한다" do
+    list = Todo::List.create!(title: "리스트", user_id: @user.id)
+    older = list.items.create!(title: "먼저 생성", completed: false, due_date: Date.new(2026, 3, 1), created_at: 2.days.ago)
+    newer = list.items.create!(title: "나중 생성", completed: false, due_date: Date.new(2026, 3, 1), created_at: 1.day.ago)
+
+    assert_equal [ newer.id, older.id ], list.sorted_items.map(&:id)
+  end
+
+  test "displayed_items는 상위 5개만 반환한다" do
+    list = Todo::List.create!(title: "리스트", user_id: @user.id)
+    6.times do |i|
+      list.items.create!(title: "할일 #{i}", due_date: Date.new(2026, 3, i + 1))
+    end
+
+    assert_equal 6, list.sorted_items.count
+    assert_equal 5, list.displayed_items.count
+  end
+
+  test "title이 없으면 유효하지 않다" do
+    list = Todo::List.new(user_id: @user.id)
+    assert_not list.valid?
+    assert list.errors[:title].any?
+  end
+
+  test "title이 100자면 유효하다" do
+    list = Todo::List.new(title: "가" * 100, user_id: @user.id)
+    assert list.valid?
+  end
+
+  test "title이 100자를 초과하면 유효하지 않다" do
+    list = Todo::List.new(title: "가" * 101, user_id: @user.id)
+    assert_not list.valid?
+  end
+end

--- a/test/services/journal/data_cleaner_test.rb
+++ b/test/services/journal/data_cleaner_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Journal::DataCleanerTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:test_user)
+    @other_user = users(:other_user)
+  end
+
+  test "대상 유저의 글을 모두 삭제한다" do
+    Journal::Post.create!(body: "글 1", user_id: @user.id)
+    Journal::Post.create!(body: "글 2", user_id: @user.id)
+
+    Journal::DataCleaner.call(user_id: @user.id)
+
+    assert_equal 0, Journal::Post.where(user_id: @user.id).count
+  end
+
+  test "타 유저의 글은 삭제하지 않는다" do
+    Journal::Post.create!(body: "내 글", user_id: @user.id)
+    Journal::Post.create!(body: "타인 글", user_id: @other_user.id)
+
+    Journal::DataCleaner.call(user_id: @user.id)
+
+    assert_equal 0, Journal::Post.where(user_id: @user.id).count
+    assert_equal 1, Journal::Post.where(user_id: @other_user.id).count
+  end
+
+  test "삭제할 데이터가 없어도 예외 없이 동작한다" do
+    assert_nothing_raised do
+      Journal::DataCleaner.call(user_id: @user.id)
+    end
+  end
+end

--- a/test/services/todo/data_cleaner_test.rb
+++ b/test/services/todo/data_cleaner_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Todo::DataCleanerTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:test_user)
+    @other_user = users(:other_user)
+  end
+
+  test "대상 유저의 리스트를 모두 삭제한다" do
+    Todo::List.create!(title: "리스트 A", user_id: @user.id)
+    Todo::List.create!(title: "리스트 B", user_id: @user.id)
+
+    Todo::DataCleaner.call(user_id: @user.id)
+
+    assert_equal 0, Todo::List.by_user(@user.id).count
+  end
+
+  test "타 유저의 리스트는 삭제하지 않는다" do
+    Todo::List.create!(title: "내 리스트", user_id: @user.id)
+    Todo::List.create!(title: "타인 리스트", user_id: @other_user.id)
+
+    Todo::DataCleaner.call(user_id: @user.id)
+
+    assert_equal 0, Todo::List.by_user(@user.id).count
+    assert_equal 1, Todo::List.by_user(@other_user.id).count
+  end
+
+  test "보관된 리스트도 삭제한다" do
+    list = Todo::List.create!(title: "보관 리스트", user_id: @user.id)
+    list.archive!
+
+    Todo::DataCleaner.call(user_id: @user.id)
+
+    assert_equal 0, Todo::List.by_user(@user.id).count
+  end
+
+  test "리스트의 하위 아이템도 함께 삭제한다" do
+    list = Todo::List.create!(title: "아이템 있는 리스트", user_id: @user.id)
+    list.items.create!(title: "할일 1")
+    list.items.create!(title: "할일 2")
+
+    assert_difference "Todo::Item.count", -2 do
+      Todo::DataCleaner.call(user_id: @user.id)
+    end
+  end
+
+  test "삭제할 데이터가 없어도 예외 없이 동작한다" do
+    assert_nothing_raised do
+      Todo::DataCleaner.call(user_id: @user.id)
+    end
+  end
+end


### PR DESCRIPTION
## 개요

전용 테스트가 없던 코어·엔진 구성 요소 4개 영역에 테스트를 추가한다. (Redmine #353)

프로덕션 코드 변경 없음. `test/` 트리에 신규 파일 5개 추가.

## 추가한 테스트

| 파일 | 검증 내용 |
|---|---|
| `test/services/todo/data_cleaner_test.rb` | 대상 유저 삭제 · **타 유저 데이터 미삭제** · 보관 리스트 삭제 · 하위 아이템 연쇄 삭제 · 0건 동작 |
| `test/services/journal/data_cleaner_test.rb` | 대상 유저 삭제 · 타 유저 데이터 미삭제 · 0건 동작 |
| `test/models/todo/list_test.rb` | `active`·`archived`·`by_user` 스코프 · `archive!`/`unarchive!` · `sorted_items`·`displayed_items` · title 검증 |
| `test/models/push_subscription_test.rb` | 검증 · 만료/무효 구독 시 `destroy`+`false` · 기타 `WebPush::Error` 시 레코드 유지+`false` |
| `test/helpers/navigation_helper_test.rb` | 인증/비인증 항목 구성 · 루트 경로 정확 일치 예외 · 하위 경로 prefix 매칭 |

## 배경

- `test/jobs/plugin_data_deletion_job_test.rb`는 `UserPlugin` 삭제만 검증하고 실제 플러그인 데이터(List/Post) 삭제는 검증하지 않았음. `Todo::DataCleaner`의 실제 삭제 검증은 전무했음.
- `Todo::List` 보관 기능 관련 스코프·메서드에 모델 테스트가 없었음.

## 구현 노트

- minitest 6.0.6에 `minitest/mock`이 없어 `WebPush.payload_send`는 기존 관례(`test/jobs/todo/reminder_job_test.rb`)를 따라 임시 재정의 헬퍼로 스텁.
- `NavigationHelper`는 프로젝트 최초 헬퍼 테스트로, 헬퍼 include + 협력자 스텁 방식으로 작성.

## 테스트

- `bin/rails test`: 247 runs, 558 assertions, 0 failures, 0 errors, 0 skips
- `bin/rubocop`: 139 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)