### PR TITLE
feat: js_admin 기반 관리자 UI 구축

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "tailwindcss-rails"
 gem "solid_queue"
 # Mission Control for Rails Jobs [https://github.com/rails/mission_control-jobs]
 gem "mission_control-jobs"
+# Generic admin UI for Active Record models
+gem "js_admin"
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,12 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    js_admin (0.1.0)
+      importmap-rails (>= 2.0, < 3.0)
+      rails (>= 8.1.3, < 9.0)
+      stimulus-rails (>= 1.3.4, < 2.0)
+      tailwindcss-rails (>= 4.4.0, < 5.0)
+      turbo-rails (>= 2.0.23, < 3.0)
     json (2.21.1)
     jwt (3.1.2)
       base64
@@ -391,6 +397,7 @@ DEPENDENCIES
   debug
   importmap-rails
   journal!
+  js_admin
   lucide-rails
   mission_control-jobs
   propshaft

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "../builds/tailwind/js_admin";
 
 @layer components {
   .legal-content {

--- a/app/controllers/concerns/admin_authorization.rb
+++ b/app/controllers/concerns/admin_authorization.rb
@@ -1,0 +1,17 @@
+module AdminAuthorization
+  extend ActiveSupport::Concern
+
+  include Authentication
+
+  included do
+    before_action :require_admin
+  end
+
+  private
+
+  def require_admin
+    return if current_user&.admin?
+
+    head :forbidden
+  end
+end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,7 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@hotwired/hotwire-native-bridge", to: "@hotwired--hotwire-native-bridge.js" # @1.2.2
+
+pin "js_admin", to: "js_admin/application.js", preload: true
+pin "js_admin/controllers/theme_controller", to: "js_admin/controllers/theme_controller.js", preload: true
+pin "js_admin/controllers/flash_controller", to: "js_admin/controllers/flash_controller.js", preload: true

--- a/config/initializers/js_admin.rb
+++ b/config/initializers/js_admin.rb
@@ -1,0 +1,14 @@
+JSAdmin.configure do |config|
+  config.include_models "User",
+    "UserPlugin",
+    "PushNotificationSetting",
+    "PushSubscription",
+    "Todo::List",
+    "Todo::Item",
+    "Journal::Post"
+  config.display_name_methods = %i[name title email_address body id]
+end
+
+Rails.application.config.to_prepare do
+  JSAdmin::ApplicationController.include AdminAuthorization
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount JSAdmin::Engine => "/admin"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260731172417_add_admin_to_users.rb
+++ b/db/migrate/20260731172417_add_admin_to_users.rb
@@ -1,0 +1,6 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+    add_index :users, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_18_193900) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_31_172417) do
   create_table "push_notification_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "enabled", default: true, null: false
@@ -54,12 +54,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_18_193900) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.datetime "email_verified_at"
     t.string "name", null: false
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
+    t.index ["admin"], name: "index_users_on_admin"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,11 @@
-user = User.find_or_create_by!(email_address: "test@test.com") do |u|
-  u.name = "test"
-  u.password = "qwer1234"
-  u.email_verified_at = Time.current
+user = User.find_or_initialize_by(email_address: "test@test.com")
+if user.new_record?
+  user.name = "test"
+  user.password = "qwer1234"
+  user.email_verified_at = Time.current
 end
+user.admin = true
+user.save!
 puts "User: #{user.email_address}"
 
 list1 = Todo::List.find_or_create_by!(title: "오늘 할 일", user_id: user.id)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,9 +3,11 @@ test_user:
   email_address: test@example.com
   password_digest: <%= BCrypt::Password.create("password123") %>
   email_verified_at: <%= Time.current %>
+  admin: true
 
 other_user:
   name: 다른사용자
   email_address: other@example.com
   password_digest: <%= BCrypt::Password.create("password123") %>
   email_verified_at: <%= Time.current %>
+  admin: false

--- a/test/integration/js_admin_test.rb
+++ b/test/integration/js_admin_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class JSAdminTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:test_user)
+  end
+
+  test "비인증 사용자는 로그인 페이지로 이동한다" do
+    get "/admin"
+
+    assert_redirected_to Rails.application.routes.url_helpers.new_session_path
+    assert_equal "http://www.example.com/admin/", session[:return_to_after_authenticating]
+  end
+
+  test "관리자는 어드민에 접근할 수 있다" do
+    sign_in_as @user
+
+    get "/admin"
+
+    assert_response :success
+    assert_select "a[href='/admin/user']"
+    assert_select "a[href='/admin/user_plugin']"
+    assert_select "a[href='/admin/push_notification_setting']"
+    assert_select "a[href='/admin/push_subscription']"
+    assert_select "a[href='/admin/todo--list']"
+    assert_select "a[href='/admin/todo--item']"
+    assert_select "a[href='/admin/journal--post']"
+  end
+
+  test "일반 사용자는 어드민에 접근할 수 없다" do
+    sign_in_as users(:other_user)
+
+    get "/admin"
+
+    assert_response :forbidden
+  end
+
+  test "허용한 코어와 엔진 모델만 노출한다" do
+    expected_model_names = [
+      "Journal::Post",
+      "PushNotificationSetting",
+      "PushSubscription",
+      "Todo::Item",
+      "Todo::List",
+      "User",
+      "UserPlugin"
+    ]
+
+    assert_equal expected_model_names, JSAdmin.resources.map { |resource| resource.model_class.name }.sort
+  end
+
+  test "멀티 DB 엔진 모델 목록에 접근할 수 있다" do
+    sign_in_as @user
+
+    get "/admin/todo--list"
+    assert_response :success
+
+    get "/admin/journal--post"
+    assert_response :success
+  end
+
+  test "Hotwire Native 비인증 요청은 401을 반환한다" do
+    get "/admin", headers: { "User-Agent" => "Console Hotwire Native iOS" }
+
+    assert_response :unauthorized
+    assert_equal "http://www.example.com/admin/", session[:return_to_after_authenticating]
+  end
+end

--- a/test/integration/mypage/users_test.rb
+++ b/test/integration/mypage/users_test.rb
@@ -13,10 +13,16 @@ class Mypage::UsersTest < ActionDispatch::IntegrationTest
 
   test "올바른 현재 비밀번호로 변경하면 재로그인이 필요하다" do
     patch mypage_user_url, params: {
-      user: { current_password: "password123", password: "newpassword456", password_confirmation: "newpassword456" }
+      user: {
+        current_password: "password123",
+        password: "newpassword456",
+        password_confirmation: "newpassword456",
+        admin: false
+      }
     }
     assert_response :see_other
     assert_redirected_to new_session_path
+    assert @user.reload.admin?
     follow_redirect!
     assert_equal I18n.t("settings.password.updated_please_login"), flash[:notice]
   end

--- a/test/integration/registrations_test.rb
+++ b/test/integration/registrations_test.rb
@@ -14,7 +14,8 @@ class RegistrationsTest < ActionDispatch::IntegrationTest
             name: "신규사용자",
             email_address: "new@example.com",
             password: "password1",
-            password_confirmation: "password1"
+            password_confirmation: "password1",
+            admin: true
           },
           terms_agreed: "1",
           privacy_agreed: "1"
@@ -23,6 +24,7 @@ class RegistrationsTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to verify_pending_registration_path
+    assert_not User.find_by!(email_address: "new@example.com").admin?
   end
 
   test "약관 미동의 시 가입에 실패한다" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,12 @@ class UserTest < ActiveSupport::TestCase
     @user = users(:test_user)
   end
 
+  test "신규 사용자는 일반 사용자로 생성된다" do
+    user = User.new
+
+    assert_not user.admin?
+  end
+
   test "plugin_enabled?는 레코드가 없으면 true를 반환한다" do
     assert @user.plugin_enabled?(:posts)
   end


### PR DESCRIPTION
## 변경 사항

- `js_admin 0.1.0`을 설치하고 `/admin`에 엔진을 마운트했습니다.
- `User`, `UserPlugin`, `PushNotificationSetting`, `PushSubscription`, `Todo`, `Journal` 모델을 노출합니다.
- `users.admin` 권한과 `AdminAuthorization`을 추가해 관리자만 접근할 수 있도록 했습니다.
- 회원가입과 마이페이지 요청으로 관리자 권한을 변경할 수 없도록 보호했습니다.
- `test@test.com` 시드 사용자를 관리자로 설정했습니다.
- Importmap과 Tailwind 엔진 CSS 빌드를 통합했습니다.

## 배경

Redmine 이슈 357의 제네릭 어드민 UI 도입 요구사항을 구현합니다. 기존 세션 인증을 재사용하면서 일반 사용자의 어드민 접근을 차단하고, 코어 및 엔진별 멀티 DB 모델을 관리할 수 있도록 구성했습니다.

## 영향

- 비로그인 사용자는 기존 로그인 흐름을 따릅니다.
- 로그인한 일반 사용자는 `/admin`에서 `403 Forbidden`을 받습니다.
- 관리자만 어드민 CRUD UI에 접근할 수 있습니다.
- 기존 사용자는 마이그레이션 후 `admin: false`이며 별도 권한 지정이 필요합니다.
- 현재 `js_admin`에는 필드별 노출 제어가 없어 `User.password_digest`와 `PushSubscription` 키가 관리자 화면에 표시되는 제한이 있습니다.

## 검증

- `PARALLEL_WORKERS=1 bin/rails test`: 274 runs, 748 assertions, 0 failures
- `bin/rubocop --no-server --cache false --no-parallel`: 149 files, 0 offenses
- `bundle exec brakeman --no-pager`: 0 security warnings
- `bin/rails db:seed`: `test@test.com: admin=true` 확인
- `git diff --check`: 통과