### PR TITLE
feat: 사용자 테마와 Hotwire Native UI 동기화

### DIFF
--- a/.agents/rules/hotwire.md
+++ b/.agents/rules/hotwire.md
@@ -74,6 +74,9 @@ Rails 웹 UI는 JavaScript 애플리케이션을 별도로 만들지 않고 서�
 ## Layout과 DOM 계약
 
 - 모든 top-level 화면은 고유한 `<title>`을 제공한다.
+- `application`과 `blank` layout의 `<main>` 여백은 `layout_main_classes`를 사용하며 Native 분기를 중복 작성하지 않는다.
+- top-level 화면을 추가하거나 경로를 변경하면 `HotwireNativePageContractTest`에 경로와 title을 등록한다.
+- Native에서 숨기는 제목 위에 `pt-*` 또는 `py-*` 여백이 있으면 `data-native-top-flush` 계약과 모바일 viewport의 실제 상단 좌표를 검증한다.
 - flash는 모든 layout에서 동일한 `#flash` target을 사용한다.
 - partial의 root ID는 Stream 교체 전후 동일해야 한다.
 - HTML의 의미 구조와 접근성을 유지하고 Turbo target을 위해 중복 wrapper를 만들지 않는다.
@@ -94,7 +97,9 @@ Hotwire 동작을 변경하면 다음 항목을 변경 범위에 맞게 검증�
   - target 영역, 빈 상태, 정렬, flash의 실제 갱신
   - 직접 URL 접근과 새로고침
   - 데스크톱과 모바일에서 동일 기능 동작
+  - Native User-Agent와 모바일 viewport에서 상단 좌표와 document overflow
 - `data-turbo="false"`, 수동 navigation, 수동 `fetch`를 추가했다면 Turbo로 해결할 수 없는 이유와 fallback test가 반드시 있어야 한다.
+- Native top-level UI를 변경하면 `bin/rails test test/integration/hotwire_native_page_contract_test.rb`와 `bin/rails test test/system/hotwire_native_layout_test.rb`를 실행한다.
 
 ## 리뷰 체크리스트
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare && bin/rails test
 
+      - name: Run system tests
+        env:
+          RAILS_ENV: test
+        run: bin/rails test:system
+
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v7
         if: failure()

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -45,6 +45,10 @@
     }
   }
 
+  .legal-content > h2:first-child {
+    margin-top: 0;
+  }
+
   .legal-content p {
     margin-bottom: 0.75rem;
   }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,6 +1,32 @@
 @import "tailwindcss";
 @import "../builds/tailwind/js_admin";
 
+@custom-variant dark {
+  &:where(.dark, .dark *) {
+    @slot;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    &:where(.theme-system, .theme-system *) {
+      @slot;
+    }
+  }
+}
+
+@layer base {
+  html.theme-light {
+    color-scheme: light;
+  }
+
+  html.theme-dark {
+    color-scheme: dark;
+  }
+
+  html.theme-system {
+    color-scheme: light dark;
+  }
+}
+
 @layer components {
   .legal-content {
     font-size: 0.875rem;
@@ -13,6 +39,10 @@
     margin-top: 2rem;
     margin-bottom: 0.75rem;
     color: var(--color-gray-900);
+
+    @variant dark {
+      color: var(--color-white);
+    }
   }
 
   .legal-content p {
@@ -38,6 +68,10 @@
   .legal-content strong {
     font-weight: 600;
     color: var(--color-gray-900);
+
+    @variant dark {
+      color: var(--color-white);
+    }
   }
 
   .legal-content table {
@@ -48,6 +82,10 @@
 
   .legal-content thead tr {
     background-color: var(--color-gray-50);
+
+    @variant dark {
+      background-color: var(--color-gray-700);
+    }
   }
 
   .legal-content th {
@@ -55,41 +93,27 @@
     text-align: left;
     font-weight: 500;
     border-bottom: 1px solid var(--color-gray-200);
+
+    @variant dark {
+      border-bottom-color: var(--color-gray-600);
+    }
   }
 
   .legal-content td {
     padding: 0.5rem 1rem;
     border-bottom: 1px solid var(--color-gray-200);
+
+    @variant dark {
+      border-bottom-color: var(--color-gray-600);
+    }
   }
 
   .legal-content hr {
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
     border-color: var(--color-gray-200);
-  }
 
-  @media (prefers-color-scheme: dark) {
-    .legal-content h2 {
-      color: var(--color-white);
-    }
-
-    .legal-content strong {
-      color: var(--color-white);
-    }
-
-    .legal-content thead tr {
-      background-color: var(--color-gray-700);
-    }
-
-    .legal-content th {
-      border-bottom-color: var(--color-gray-600);
-    }
-
-    .legal-content td {
-      border-bottom-color: var(--color-gray-600);
-    }
-
-    .legal-content hr {
+    @variant dark {
       border-color: var(--color-gray-700);
     }
   }

--- a/app/controllers/mypage/themes_controller.rb
+++ b/app/controllers/mypage/themes_controller.rb
@@ -1,0 +1,14 @@
+class Mypage::ThemesController < Mypage::ApplicationController
+  def update
+    if current_user.update(theme: params.dig(:theme, :value))
+      respond_to do |format|
+        format.turbo_stream { flash.now[:notice] = t("settings.theme.updated") }
+        format.html do
+          redirect_to mypage_user_path, status: :see_other, notice: t("settings.theme.updated")
+        end
+      end
+    else
+      respond_with_error(current_user.errors.full_messages.join(", "), redirect_url: mypage_user_path)
+    end
+  end
+end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -1,0 +1,9 @@
+module LayoutHelper
+  NATIVE_MAIN_CLASSES = "px-4 pb-4 sm:px-6 sm:pb-6".freeze
+  WEB_MAIN_CLASSES = "p-8".freeze
+
+  def layout_main_classes(additional_classes = nil)
+    spacing_classes = hotwire_native_app? ? NATIVE_MAIN_CLASSES : WEB_MAIN_CLASSES
+    class_names(spacing_classes, additional_classes)
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,2 +1,3 @@
 import "@hotwired/turbo-rails"
 import "controllers"
+import "service_worker_registration"

--- a/app/javascript/controllers/bridge/theme_controller.js
+++ b/app/javascript/controllers/bridge/theme_controller.js
@@ -1,0 +1,36 @@
+import { BridgeComponent } from "@hotwired/hotwire-native-bridge"
+
+const THEMES = ["system", "light", "dark"]
+
+export default class extends BridgeComponent {
+  static component = "theme"
+
+  initialize() {
+    super.initialize()
+    this.syncFromRenderedPage = this.syncFromRenderedPage.bind(this)
+  }
+
+  connect() {
+    super.connect()
+    document.removeEventListener("turbo:render", this.syncFromRenderedPage)
+    document.addEventListener("turbo:render", this.syncFromRenderedPage)
+    queueMicrotask(() => this.syncFromRenderedPage())
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:render", this.syncFromRenderedPage)
+    super.disconnect()
+  }
+
+  sync(event) {
+    const owner = event?.detail?.owner || document.body.dataset.themeOwner
+    const preference = event?.detail?.preference || document.body.dataset.themePreference
+    if (!owner || !THEMES.includes(preference)) return
+
+    this.send("sync", { owner, preference })
+  }
+
+  syncFromRenderedPage() {
+    this.sync()
+  }
+}

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
+
+const THEMES = ["system", "light", "dark"]
+const LIGHT_COLOR_MEDIA = "(prefers-color-scheme: light)"
+const DARK_COLOR_MEDIA = "(prefers-color-scheme: dark)"
+
+export default class extends Controller {
+  static targets = ["lightColor", "darkColor"]
+
+  static values = {
+    owner: String,
+    preference: String
+  }
+
+  connect() {
+    this.syncFromRenderedPage = this.syncFromRenderedPage.bind(this)
+    document.addEventListener("turbo:render", this.syncFromRenderedPage)
+    this.applyTheme(this.preferenceValue)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:render", this.syncFromRenderedPage)
+  }
+
+  select(event) {
+    const preference = event.target.value
+    if (!THEMES.includes(preference)) return
+
+    this.preferenceValue = preference
+    this.applyTheme(preference)
+    Turbo.cache.clear()
+    event.target.form.requestSubmit()
+  }
+
+  syncFromRenderedPage() {
+    const owner = document.body.dataset.themeOwner
+    const preference = document.body.dataset.themePreference
+    if (!owner || owner === this.ownerValue || !THEMES.includes(preference)) return
+
+    this.ownerValue = owner
+    this.preferenceValue = preference
+    this.applyTheme(preference)
+    Turbo.cache.clear()
+  }
+
+  applyTheme(preference) {
+    const root = document.documentElement
+
+    THEMES.forEach((theme) => {
+      root.classList.toggle(`theme-${theme}`, theme === preference)
+    })
+    root.classList.toggle("dark", preference === "dark")
+
+    if (!this.hasLightColorTarget || !this.hasDarkColorTarget) return
+
+    this.lightColorTarget.media = preference === "light" ? "all" :
+      preference === "dark" ? "not all" : LIGHT_COLOR_MEDIA
+    this.darkColorTarget.media = preference === "dark" ? "all" :
+      preference === "light" ? "not all" : DARK_COLOR_MEDIA
+  }
+}

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -33,6 +33,27 @@ export default class extends Controller {
     event.target.form.requestSubmit()
   }
 
+  submitEnd(event) {
+    const preference = this.preferenceValue
+
+    if (event.detail.success) {
+      document.body.dataset.themePreference = preference
+      this.dispatch("sync", {
+        detail: { owner: this.ownerValue, preference }
+      })
+      return
+    }
+
+    const renderedPreference = document.body.dataset.themePreference
+    if (!THEMES.includes(renderedPreference)) return
+
+    this.preferenceValue = renderedPreference
+    this.applyTheme(renderedPreference)
+    event.target.querySelectorAll("input[name='theme[value]']").forEach((input) => {
+      input.checked = input.value === renderedPreference
+    })
+  }
+
   syncFromRenderedPage() {
     const owner = document.body.dataset.themeOwner
     const preference = document.body.dataset.themePreference

--- a/app/javascript/service_worker_registration.js
+++ b/app/javascript/service_worker_registration.js
@@ -1,0 +1,9 @@
+const SERVICE_WORKER_PATH = "/service-worker.js"
+const SERVICE_WORKER_SCOPE = "/"
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register(SERVICE_WORKER_PATH, { scope: SERVICE_WORKER_SCOPE })
+      .catch((error) => console.error("ServiceWorker registration failed:", error))
+  })
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  enum :theme, { system: "system", light: "light", dark: "dark" }, prefix: true, validate: true
+
   has_secure_password
   has_many :sessions, dependent: :destroy
 

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -21,8 +21,9 @@
 <%= yield :head %>
 
 <%= tag.link rel: "manifest", href: main_app.pwa_manifest_path(format: :json) %>
-<meta name="theme-color" content="#2563eb" media="(prefers-color-scheme: light)">
-<meta name="theme-color" content="#1e40af" media="(prefers-color-scheme: dark)">
+<meta name="color-scheme" content="light dark">
+<meta name="theme-color" content="#2563eb" media="(prefers-color-scheme: light)" data-theme-target="lightColor">
+<meta name="theme-color" content="#1e40af" media="(prefers-color-scheme: dark)" data-theme-target="darkColor">
 
 <link rel="icon" href="/icon.png" type="image/png">
 <link rel="apple-touch-icon" href="/icon.png">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -30,21 +30,3 @@
 <%= stylesheet_link_tag "application", "tailwind", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "hotwire_native", "data-turbo-track": "reload" if hotwire_native_app? %>
 <%= javascript_importmap_tags %>
-
-<script>
-  if ('serviceWorker' in navigator) {
-    window.addEventListener('load', function() {
-      navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
-        .then(function(registration) {
-          <% if Rails.env.development? %>
-          console.log('ServiceWorker registration successful');
-          <% end %>
-        })
-        .catch(function(error) {
-          <% if Rails.env.development? %>
-          console.log('ServiceWorker registration failed:', error);
-          <% end %>
-        });
-    });
-  }
-</script>

--- a/app/views/layouts/_htmldoc.html.erb
+++ b/app/views/layouts/_htmldoc.html.erb
@@ -4,7 +4,8 @@
 <!DOCTYPE html>
 <html lang="ko"
       class="h-full theme-<%= theme_preference %><%= " dark" if theme_preference == "dark" %>"
-      data-controller="theme"
+      data-controller="theme bridge--theme"
+      data-action="theme:sync->bridge--theme#sync"
       data-theme-owner-value="<%= current_user ? "user-#{current_user.id}" : "guest" %>"
       data-theme-preference-value="<%= theme_preference %>">
   <head>

--- a/app/views/layouts/_htmldoc.html.erb
+++ b/app/views/layouts/_htmldoc.html.erb
@@ -1,14 +1,21 @@
 <% turbo_refreshes_with method: :morph, scroll: :preserve %>
+<% theme_preference = current_user&.theme || "system" %>
 
 <!DOCTYPE html>
-<html lang="ko" class="h-full">
+<html lang="ko"
+      class="h-full theme-<%= theme_preference %><%= " dark" if theme_preference == "dark" %>"
+      data-controller="theme"
+      data-theme-owner-value="<%= current_user ? "user-#{current_user.id}" : "guest" %>"
+      data-theme-preference-value="<%= theme_preference %>">
   <head>
     <title><%= content_for(:title) || "Console" %></title>
 
     <%= render "layouts/head" %>
   </head>
 
-  <body class="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors duration-200 break-keep">
+  <body class="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors duration-200 break-keep"
+        data-theme-owner="<%= current_user ? "user-#{current_user.id}" : "guest" %>"
+        data-theme-preference="<%= theme_preference %>">
     <div id="flash">
       <%= render "layouts/shared/alert" %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <div class="<%= hotwire_native_app? ? '' : 'lg:pl-64' %>">
-    <main class="<%= hotwire_native_app? ? 'px-4 pb-4 sm:px-6 sm:pb-6' : 'p-8' %> text-gray-900 dark:text-white">
+    <main class="<%= layout_main_classes("text-gray-900 dark:text-white") %>">
       <%= yield %>
     </main>
     <% unless hotwire_native_app? %>

--- a/app/views/layouts/blank.html.erb
+++ b/app/views/layouts/blank.html.erb
@@ -1,5 +1,5 @@
 <%= render "layouts/htmldoc" do %>
-  <main class="p-8">
+  <main class="<%= layout_main_classes %>">
     <%= yield %>
   </main>
 <% end %>

--- a/app/views/mypage/themes/update.turbo_stream.erb
+++ b/app/views/mypage/themes/update.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update "flash", partial: "layouts/shared/alert" %>

--- a/app/views/mypage/users/show.html.erb
+++ b/app/views/mypage/users/show.html.erb
@@ -10,6 +10,73 @@
   <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mb-6">
     <div class="p-6">
       <div class="flex items-center mb-4">
+        <%= lucide_icon "palette", class: "w-6 h-6 text-blue-600 dark:text-blue-400 mr-3" %>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+          <%= t("settings.theme.title") %>
+        </h2>
+      </div>
+
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
+        <%= t("settings.theme.description") %>
+      </p>
+
+      <%= form_with url: mypage_theme_path, method: :patch, scope: :theme, data: { turbo_stream: true } do |form| %>
+        <fieldset>
+          <legend class="sr-only"><%= t("settings.theme.title") %></legend>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <%= form.radio_button :value, "system",
+                  checked: current_user.theme_system?,
+                  class: "peer sr-only",
+                  data: { action: "change->theme#select" } %>
+              <%= form.label :value_system,
+                  class: "flex h-full cursor-pointer items-start gap-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700 peer-checked:border-blue-600 peer-checked:bg-blue-50 dark:peer-checked:border-blue-400 dark:peer-checked:bg-blue-900/20 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500" do %>
+                <%= lucide_icon "monitor", class: "w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" %>
+                <span>
+                  <span class="block text-sm font-medium text-gray-900 dark:text-white"><%= t("settings.theme.system") %></span>
+                  <span class="mt-1 block text-xs text-gray-600 dark:text-gray-400"><%= t("settings.theme.system_description") %></span>
+                </span>
+              <% end %>
+            </div>
+
+            <div>
+              <%= form.radio_button :value, "light",
+                  checked: current_user.theme_light?,
+                  class: "peer sr-only",
+                  data: { action: "change->theme#select" } %>
+              <%= form.label :value_light,
+                  class: "flex h-full cursor-pointer items-start gap-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700 peer-checked:border-blue-600 peer-checked:bg-blue-50 dark:peer-checked:border-blue-400 dark:peer-checked:bg-blue-900/20 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500" do %>
+                <%= lucide_icon "sun", class: "w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" %>
+                <span>
+                  <span class="block text-sm font-medium text-gray-900 dark:text-white"><%= t("settings.theme.light") %></span>
+                  <span class="mt-1 block text-xs text-gray-600 dark:text-gray-400"><%= t("settings.theme.light_description") %></span>
+                </span>
+              <% end %>
+            </div>
+
+            <div>
+              <%= form.radio_button :value, "dark",
+                  checked: current_user.theme_dark?,
+                  class: "peer sr-only",
+                  data: { action: "change->theme#select" } %>
+              <%= form.label :value_dark,
+                  class: "flex h-full cursor-pointer items-start gap-3 rounded-lg border border-gray-200 dark:border-gray-700 p-4 transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700 peer-checked:border-blue-600 peer-checked:bg-blue-50 dark:peer-checked:border-blue-400 dark:peer-checked:bg-blue-900/20 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-blue-500" do %>
+                <%= lucide_icon "moon", class: "w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" %>
+                <span>
+                  <span class="block text-sm font-medium text-gray-900 dark:text-white"><%= t("settings.theme.dark") %></span>
+                  <span class="mt-1 block text-xs text-gray-600 dark:text-gray-400"><%= t("settings.theme.dark_description") %></span>
+                </span>
+              <% end %>
+            </div>
+          </div>
+        </fieldset>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mb-6">
+    <div class="p-6">
+      <div class="flex items-center mb-4">
         <%= lucide_icon "user", class: "w-6 h-6 text-blue-600 dark:text-blue-400 mr-3" %>
         <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
           <%= t('settings.profile.title') %>

--- a/app/views/mypage/users/show.html.erb
+++ b/app/views/mypage/users/show.html.erb
@@ -20,7 +20,10 @@
         <%= t("settings.theme.description") %>
       </p>
 
-      <%= form_with url: mypage_theme_path, method: :patch, scope: :theme, data: { turbo_stream: true } do |form| %>
+      <%= form_with url: mypage_theme_path,
+          method: :patch,
+          scope: :theme,
+          data: { turbo_stream: true, action: "turbo:submit-end->theme#submitEnd" } do |form| %>
         <fieldset>
           <legend class="sr-only"><%= t("settings.theme.title") %></legend>
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title) { t("pages.privacy") } %>
 
-<div class="flex items-start justify-center min-h-[calc(100vh-12rem)] py-8">
+<div class="flex items-start justify-center min-h-[calc(100vh-12rem)] py-8" data-native-top-flush>
   <div class="mx-auto w-full max-w-5xl p-8 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white mb-8"
         data-native-page-title><%= t("pages.privacy") %></h1>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title) { t("pages.terms") } %>
 
-<div class="flex items-start justify-center min-h-[calc(100vh-12rem)] py-8">
+<div class="flex items-start justify-center min-h-[calc(100vh-12rem)] py-8" data-native-top-flush>
   <div class="mx-auto w-full max-w-5xl p-8 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white mb-8"
         data-native-page-title><%= t("pages.terms") %></h1>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
+pin "service_worker_registration"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -306,6 +306,16 @@ ko:
     profile:
       title: "프로필"
       description: "계정 정보를 확인하세요."
+    theme:
+      title: "테마"
+      description: "앱에서 사용할 화면 테마를 선택하세요. 선택한 설정은 계정에 저장됩니다."
+      system: "시스템 설정"
+      system_description: "기기의 화면 설정을 따릅니다."
+      light: "라이트"
+      light_description: "항상 밝은 화면을 사용합니다."
+      dark: "다크"
+      dark_description: "항상 어두운 화면을 사용합니다."
+      updated: "테마가 변경되었습니다."
     password:
       title: "비밀번호 변경"
       description: "보안을 위해 주기적으로 비밀번호를 변경하세요."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   namespace :mypage do
     resource :user, only: %i[ show update ]
+    resource :theme, only: :update
     resources :push_subscriptions, only: %i[ create destroy ]
     resources :plugins, only: %i[ index ] do
       member do

--- a/db/migrate/20260802000000_add_theme_to_users.rb
+++ b/db/migrate/20260802000000_add_theme_to_users.rb
@@ -1,0 +1,5 @@
+class AddThemeToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :theme, :string, default: "system", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_172417) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_000000) do
   create_table "push_notification_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "enabled", default: true, null: false
@@ -60,6 +60,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_172417) do
     t.datetime "email_verified_at"
     t.string "name", null: false
     t.string "password_digest", null: false
+    t.string "theme", default: "system", null: false
     t.datetime "updated_at", null: false
     t.index ["admin"], name: "index_users_on_admin"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,7 @@ test_user:
   password_digest: <%= BCrypt::Password.create("password123") %>
   email_verified_at: <%= Time.current %>
   admin: true
+  theme: system
 
 other_user:
   name: 다른사용자
@@ -11,3 +12,4 @@ other_user:
   password_digest: <%= BCrypt::Password.create("password123") %>
   email_verified_at: <%= Time.current %>
   admin: false
+  theme: system

--- a/test/helpers/layout_helper_test.rb
+++ b/test/helpers/layout_helper_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class LayoutHelperTest < ActionView::TestCase
+  include LayoutHelper
+
+  attr_accessor :native_app
+
+  test "웹 main 여백을 반환한다" do
+    self.native_app = false
+
+    assert_equal "p-8 text-gray-900", layout_main_classes("text-gray-900")
+  end
+
+  test "Native main 여백을 반환한다" do
+    self.native_app = true
+
+    assert_equal "px-4 pb-4 sm:px-6 sm:pb-6 text-gray-900", layout_main_classes("text-gray-900")
+  end
+
+  private
+
+  def hotwire_native_app?
+    native_app
+  end
+end

--- a/test/integration/hotwire_native_page_contract_test.rb
+++ b/test/integration/hotwire_native_page_contract_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class HotwireNativePageContractTest < ActionDispatch::IntegrationTest
+  NATIVE_HEADERS = { "User-Agent" => "Console Hotwire Native iOS" }.freeze
+  TOP_PADDING_CLASS = /\A(?:[a-z]+:)*(?:pt|py)-/.freeze
+
+  setup do
+    @user = users(:test_user)
+    @post = Journal::Post.create!(body: "Native 페이지 계약", user_id: @user.id)
+    @list = Todo::List.create!(title: "Native 페이지 계약", user_id: @user.id)
+  end
+
+  test "공개 페이지가 Native 제목과 상단 여백 계약을 지킨다" do
+    pages = {
+      root_url => "Console",
+      new_session_url => I18n.t("forms.buttons.sign_in"),
+      new_registration_url => I18n.t("forms.buttons.sign_up"),
+      verify_pending_registration_url => I18n.t("registrations.verify_pending.title"),
+      new_password_url => I18n.t("forms.buttons.forgot_password"),
+      edit_password_url(@user.password_reset_token) => I18n.t("forms.buttons.reset_password"),
+      terms_url => I18n.t("pages.terms"),
+      privacy_url => I18n.t("pages.privacy")
+    }
+
+    pages.each { |path, title| assert_native_page_contract(path, title:) }
+  end
+
+  test "인증 페이지가 Native 제목과 상단 여백 계약을 지킨다" do
+    sign_in_as @user
+
+    pages = {
+      root_url => "대시보드",
+      mypage_user_url => I18n.t("settings.mypage.title"),
+      mypage_plugins_url => I18n.t("settings.plugins.title"),
+      mypage_push_notifications_url => I18n.t("settings.push_notifications.page_title"),
+      posts.root_url => "포스트",
+      posts.post_url(@post) => "포스트 상세",
+      posts.edit_post_url(@post) => "포스트 수정",
+      todo.lists_url => "할 일 목록",
+      todo.list_url(@list) => @list.title,
+      todo.new_list_url => "새 할 일 목록",
+      todo.edit_list_url(@list) => "할 일 목록 수정"
+    }
+
+    pages.each { |path, title| assert_native_page_contract(path, title:) }
+  end
+
+  private
+
+  def assert_native_page_contract(path, title:)
+    get path, headers: NATIVE_HEADERS
+
+    assert_response :success, "#{path} Native 요청이 성공해야 합니다"
+    assert_select "link[rel='stylesheet'][href*='hotwire_native']", count: 1
+    assert_select "main.px-4.pb-4", count: 1
+    assert_select "main.p-8", count: 0
+    assert_page_title(path, title)
+    assert_visible_headings_are_marked(path)
+    assert_top_padding_is_flushable(path)
+  end
+
+  def assert_page_title(path, expected_title)
+    actual_title = css_select("title").first&.text&.strip
+    assert_equal expected_title, actual_title, "#{path}의 title이 화면 제목과 일치해야 합니다"
+  end
+
+  def assert_visible_headings_are_marked(path)
+    css_select("h1").each do |heading|
+      marked = heading.attribute("data-native-page-title").present? ||
+        heading.ancestors.any? { |ancestor| ancestor.attribute("data-native-page-title").present? }
+
+      assert marked, "#{path}의 h1은 data-native-page-title 영역에 있어야 합니다"
+    end
+  end
+
+  def assert_top_padding_is_flushable(path)
+    css_select("[data-native-page-title]").each do |title_region|
+      title_region.ancestors.take_while { |ancestor| ancestor.name != "main" }.each do |ancestor|
+        next unless ancestor.classes.any? { |class_name| class_name.match?(TOP_PADDING_CLASS) }
+
+        assert ancestor.attribute("data-native-top-flush").present?,
+          "#{path}에서 제목 위 padding을 가진 영역은 data-native-top-flush가 필요합니다"
+      end
+    end
+  end
+end

--- a/test/integration/mypage/users_test.rb
+++ b/test/integration/mypage/users_test.rb
@@ -9,6 +9,40 @@ class Mypage::UsersTest < ActionDispatch::IntegrationTest
   test "마이페이지를 조회할 수 있다" do
     get mypage_user_url
     assert_response :success
+    assert_select "html.theme-system[data-controller~='theme'][data-theme-preference-value='system']"
+    assert_select "body[data-theme-preference='system']"
+    assert_select "input[name='theme[value]']", count: 3
+  end
+
+  test "테마를 변경할 수 있다" do
+    patch mypage_theme_url, params: { theme: { value: "dark" } }
+
+    assert_response :see_other
+    assert_redirected_to mypage_user_path
+    assert @user.reload.theme_dark?
+
+    follow_redirect!
+    assert_select "html.theme-dark.dark[data-theme-preference-value='dark']"
+  end
+
+  test "Turbo Stream으로 테마를 변경하면 flash만 갱신한다" do
+    patch mypage_theme_url,
+      params: { theme: { value: "light" } },
+      headers: turbo_stream_headers
+
+    assert_response :success
+    assert @user.reload.theme_light?
+    assert_select "turbo-stream[action='update'][target='flash']"
+  end
+
+  test "지원하지 않는 테마로 변경할 수 없다" do
+    patch mypage_theme_url,
+      params: { theme: { value: "unsupported" } },
+      headers: turbo_stream_headers
+
+    assert_response :unprocessable_entity
+    assert @user.reload.theme_system?
+    assert_select "turbo-stream[action='update'][target='flash']"
   end
 
   test "올바른 현재 비밀번호로 변경하면 재로그인이 필요하다" do

--- a/test/integration/mypage/users_test.rb
+++ b/test/integration/mypage/users_test.rb
@@ -9,9 +9,11 @@ class Mypage::UsersTest < ActionDispatch::IntegrationTest
   test "마이페이지를 조회할 수 있다" do
     get mypage_user_url
     assert_response :success
-    assert_select "html.theme-system[data-controller~='theme'][data-theme-preference-value='system']"
+    assert_select "html.theme-system[data-controller~='theme'][data-controller~='bridge--theme'][data-theme-preference-value='system']"
+    assert_select "html[data-action~='theme:sync->bridge--theme#sync']"
     assert_select "body[data-theme-preference='system']"
     assert_select "input[name='theme[value]']", count: 3
+    assert_select "form[data-action~='turbo:submit-end->theme#submitEnd']"
   end
 
   test "테마를 변경할 수 있다" do

--- a/test/integration/pages_test.rb
+++ b/test/integration/pages_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class PagesTest < ActionDispatch::IntegrationTest
+  NATIVE_HEADERS = { "User-Agent" => "Console Hotwire Native iOS" }.freeze
+
   setup do
     @user = users(:test_user)
   end
@@ -36,5 +38,15 @@ class PagesTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href=?]", terms_path, text: I18n.t("pages.terms")
     assert_select "a[href=?]", privacy_path, text: I18n.t("pages.privacy")
+  end
+
+  test "Native 법률 페이지는 제목 위의 여백을 제거한다" do
+    [ terms_url, privacy_url ].each do |url|
+      get url, headers: NATIVE_HEADERS
+
+      assert_response :success
+      assert_select "[data-native-top-flush] [data-native-page-title]", count: 1
+      assert_select ".legal-content > h2:first-child", count: 1
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -11,6 +11,13 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.admin?
   end
 
+  test "테마는 지원하는 값만 설정할 수 있다" do
+    @user.theme = "unsupported"
+
+    assert_not @user.valid?
+    assert @user.errors[:theme].present?
+  end
+
   test "plugin_enabled?는 레코드가 없으면 true를 반환한다" do
     assert @user.plugin_enabled?(:posts)
   end

--- a/test/system/hotwire_native_layout_test.rb
+++ b/test/system/hotwire_native_layout_test.rb
@@ -1,0 +1,73 @@
+require "application_system_test_case"
+
+class HotwireNativeLayoutTest < ApplicationSystemTestCase
+  NATIVE_USER_AGENT = "Console Hotwire Native iOS"
+
+  test "Native 공개 화면은 불필요한 상단 여백과 문서 overflow가 없다" do
+    use_mobile_viewport
+    original_user_agent = page.evaluate_script("navigator.userAgent")
+    set_user_agent(NATIVE_USER_AGENT)
+
+    begin
+      assert_legal_page_top_spacing(privacy_url)
+      assert_legal_page_top_spacing(terms_url)
+
+      user = users(:test_user)
+      compact_page_paths = [
+        new_session_url,
+        new_registration_url,
+        verify_pending_registration_url,
+        new_password_url,
+        edit_password_url(user.password_reset_token)
+      ]
+      compact_page_paths.each { |path| assert_no_document_overflow(path) }
+    ensure
+      set_user_agent(original_user_agent)
+    end
+  end
+
+  private
+
+  def set_user_agent(user_agent)
+    page.driver.browser.execute_cdp("Network.setUserAgentOverride", userAgent: user_agent)
+  end
+
+  def assert_legal_page_top_spacing(path)
+    visit path
+    assert_selector ".legal-content > h2:first-child"
+
+    spacing = page.evaluate_script(<<~JS)
+      (() => {
+        const main = document.querySelector("main")
+        const pageRoot = main.firstElementChild
+        const firstHeading = document.querySelector(".legal-content > h2:first-child")
+
+        return {
+          mainTop: main.getBoundingClientRect().top,
+          pageRootTop: pageRoot.getBoundingClientRect().top,
+          firstHeadingMarginTop: parseFloat(getComputedStyle(firstHeading).marginTop)
+        }
+      })()
+    JS
+
+    assert_in_delta spacing["mainTop"], spacing["pageRootTop"], 1,
+      "#{path}의 Native 본문은 main 상단에서 바로 시작해야 합니다"
+    assert_in_delta 0, spacing["firstHeadingMarginTop"], 1,
+      "#{path}의 첫 본문 제목에는 숨겨진 페이지 제목의 여백이 남지 않아야 합니다"
+  end
+
+  def assert_no_document_overflow(path)
+    visit path
+    assert_selector "main"
+
+    dimensions = page.evaluate_script(<<~JS)
+      ({
+        viewportHeight: document.documentElement.clientHeight,
+        documentHeight: document.documentElement.scrollHeight
+      })
+    JS
+
+    assert_operator dimensions["documentHeight"], :<=, dimensions["viewportHeight"] + 1,
+      "#{path}에 불필요한 Native 문서 스크롤이 없어야 합니다"
+  end
+end

--- a/test/system/mypage_test.rb
+++ b/test/system/mypage_test.rb
@@ -12,6 +12,37 @@ class MypageTest < ApplicationSystemTestCase
     assert_text @user.email_address
   end
 
+  test "테마를 선택하면 즉시 적용되고 저장된다" do
+    sign_in_as @user
+    click_link I18n.t("navigation.mypage")
+    assert_current_path mypage_user_path
+
+    find("label[for='theme_value_dark']").click
+    assert page.evaluate_script("document.documentElement.classList.contains('dark')")
+    assert page.evaluate_script("document.documentElement.classList.contains('theme-dark')")
+    assert_text I18n.t("settings.theme.updated")
+    assert @user.reload.theme_dark?
+    assert_current_path mypage_user_path
+
+    page.execute_script(<<~JS)
+      document.body.dataset.themePreference = "system"
+      document.dispatchEvent(new CustomEvent("turbo:render", { detail: { renderMethod: "replace" } }))
+    JS
+    assert page.evaluate_script("document.documentElement.classList.contains('dark')")
+
+    page.go_back
+    assert_current_path root_path
+    assert page.evaluate_script("document.documentElement.classList.contains('dark')")
+
+    visit mypage_user_url
+
+    find("label[for='theme_value_light']").click
+    assert_not page.evaluate_script("document.documentElement.classList.contains('dark')")
+    assert page.evaluate_script("document.documentElement.classList.contains('theme-light')")
+    assert_text I18n.t("settings.theme.updated")
+    assert @user.reload.theme_light?
+  end
+
   test "비밀번호를 변경하면 재로그인이 필요하다" do
     sign_in_as @user
     visit mypage_user_url


### PR DESCRIPTION
## 변경 사항

- 사용자 테마를 `system`, `light`, `dark`로 저장하고 마이페이지에서 즉시 변경할 수 있도록 추가했습니다.
- 사용자 테마와 어드민 테마 설정을 분리하고, 사용자 테마를 Hotwire Native Bridge로 전달하도록 구성했습니다.
- Hotwire Native 화면의 공통 상단 여백과 스크롤 정책을 정리해 개인정보처리방침, 이용약관, 로그인, 회원가입, 비밀번호 찾기 화면의 표시를 통일했습니다.
- ERB에 있던 Service Worker 등록 코드를 JavaScript 모듈로 분리했습니다.
- Native UI 계약 및 모바일 화면 크기 검증을 추가하고 CI에서 시스템 테스트를 실행하도록 보강했습니다.

## 배경 및 원인

- 어드민용 다크 모드 설정과 사용자용 테마 동작이 같은 범위에서 처리되면서 사용자 화면의 시스템 테마 적용이 불안정해졌습니다.
- Hotwire Native의 화면 캐시와 레이아웃별 여백 처리 차이로 네비게이션 이후 일부 화면에 이전 테마나 중복 여백이 남을 수 있었습니다.
- 페이지별 예외 처리만으로는 같은 문제가 반복될 수 있어 사용자 테마 상태와 Native 레이아웃 계약을 공통 규칙으로 정리했습니다.

## 영향

- 사용자는 마이페이지에서 테마를 선택하고 현재 웹 화면에 즉시 적용할 수 있습니다.
- Hotwire Native 앱은 Bridge 메시지로 사용자 테마 변경을 받아 네이티브 UI와 동기화할 수 있습니다.
- 어드민 테마는 사용자 설정과 독립적으로 유지됩니다.
- Native 화면의 여백과 불필요한 스크롤이 공통 규칙으로 관리됩니다.

## 검증

- [x] `node --check app/javascript/controllers/theme_controller.js`
- [x] `node --check app/javascript/controllers/bridge/theme_controller.js`
- [x] `bin/rails test` — 283 tests, 904 assertions, 0 failures
- [x] `bin/rails test:system` — 34 tests, 708 assertions, 0 failures
- [x] `bin/rubocop` — 155 files inspected, no offenses detected
