### PR TITLE
fix: 랜딩 페이지 주요 링크 중앙 정렬 개선

### DIFF
--- a/app/views/home/landing.html.erb
+++ b/app/views/home/landing.html.erb
@@ -12,11 +12,11 @@
       </p>
       <div class="mt-8 sm:mt-10 flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4">
         <%= link_to new_registration_path,
-            class: "w-full sm:w-auto bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-500 text-white font-medium px-8 py-3 rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 text-center" do %>
+            class: "w-full sm:w-32 bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-500 text-white font-medium px-8 py-3 rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 text-center" do %>
           시작하기
         <% end %>
         <%= link_to new_session_path,
-            class: "w-full sm:w-auto bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 font-medium px-8 py-3 rounded-md transition-colors duration-200 text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900" do %>
+            class: "w-full sm:w-32 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 font-medium px-8 py-3 rounded-md transition-colors duration-200 text-center focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900" do %>
           로그인
         <% end %>
       </div>
@@ -68,9 +68,8 @@
   </section>
 
   <footer class="px-6 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="max-w-5xl mx-auto text-center text-xs text-gray-500 dark:text-gray-400">
+    <div class="max-w-5xl mx-auto flex items-center justify-center gap-4 text-xs text-gray-500 dark:text-gray-400">
       <%= link_to "이용약관", terms_path, class: "hover:text-gray-700 dark:hover:text-gray-300 transition-colors duration-200" %>
-      <span class="mx-1">|</span>
       <%= link_to "개인정보처리방침", privacy_path, class: "hover:text-gray-700 dark:hover:text-gray-300 transition-colors duration-200" %>
     </div>
   </footer>

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -28,6 +28,47 @@ class HomeSystemTest < ApplicationSystemTestCase
     assert_current_path new_session_path
   end
 
+  test "랜딩 페이지의 주요 버튼은 같은 너비로 화면 중앙에 배치된다" do
+    visit root_url
+
+    layout = page.evaluate_script(<<~JS)
+      (() => {
+        const hero = document.querySelector("section");
+        const registration = hero.querySelector("a[href='#{new_registration_path}']").getBoundingClientRect();
+        const session = hero.querySelector("a[href='#{new_session_path}']").getBoundingClientRect();
+
+        return {
+          registrationWidth: registration.width,
+          sessionWidth: session.width,
+          actionsCenter: (registration.left + session.right) / 2,
+          viewportCenter: document.documentElement.clientWidth / 2
+        };
+      })()
+    JS
+
+    assert_in_delta layout["registrationWidth"], layout["sessionWidth"], 1
+    assert_in_delta layout["viewportCenter"], layout["actionsCenter"], 1
+  end
+
+  test "랜딩 페이지의 정책 링크 묶음은 화면 중앙에 배치된다" do
+    visit root_url
+
+    layout = page.evaluate_script(<<~JS)
+      (() => {
+        const footer = document.querySelector("footer");
+        const terms = footer.querySelector("a[href='#{terms_path}']").getBoundingClientRect();
+        const privacy = footer.querySelector("a[href='#{privacy_path}']").getBoundingClientRect();
+
+        return {
+          linksCenter: (terms.left + privacy.right) / 2,
+          viewportCenter: document.documentElement.clientWidth / 2
+        };
+      })()
+    JS
+
+    assert_in_delta layout["viewportCenter"], layout["linksCenter"], 1
+  end
+
   test "대시보드에 지원되는 플러그인 위젯만 표시된다" do
     sign_in_as @user
 


### PR DESCRIPTION
## 변경 내용

- 데스크톱에서 `시작하기`와 `로그인` 버튼 너비를 동일하게 맞췄습니다.
- 모바일의 전체 너비 버튼 배치는 유지했습니다.
- 푸터 정책 링크의 구분선을 제거하고 자연스러운 텍스트 너비를 유지한 채 링크 묶음 전체를 중앙 정렬했습니다.
- 주요 버튼과 정책 링크의 실제 브라우저 좌표를 검증하는 시스템 테스트를 추가했습니다.

## 원인

버튼 너비가 문구 길이에 따라 달라 버튼 사이의 기준선이 화면 중앙에서 벗어나 보였습니다. 정책 링크는 길이가 다른 두 문구 사이의 중앙 구분선이 시각적 비대칭을 강조했습니다.

## 영향

랜딩 페이지의 주요 CTA와 정책 링크가 데스크톱과 모바일에서 더 자연스럽게 중앙 정렬됩니다. 링크 경로와 동작에는 변경이 없습니다.

## 테스트

```bash
bin/rails test test/system/home_test.rb test/system/responsive_pages_test.rb
```

- 11 runs, 563 assertions, 0 failures, 0 errors, 0 skips

## 관련 이슈

- Redmine #360