### PR TITLE
feat: 푸시 등록 정보와 발송 이력 개선

### DIFF
--- a/app/controllers/mypage/push_registrations_controller.rb
+++ b/app/controllers/mypage/push_registrations_controller.rb
@@ -13,6 +13,9 @@ class Mypage::PushRegistrationsController < Mypage::ApplicationController
           user: Current.user,
           session: Current.session,
           platform: registration_params[:platform],
+          device_model: registration_params[:device_model],
+          os_version: registration_params[:os_version],
+          app_version: registration_app_version,
           last_registered_at: Time.current
         )
         push_registration.save!
@@ -39,7 +42,19 @@ class Mypage::PushRegistrationsController < Mypage::ApplicationController
 
   private
 
+  def registration_app_version
+    return Rails.application.config.x.app_version if registration_params[:platform] == "web"
+
+    registration_params[:app_version]
+  end
+
   def registration_params
-    params.require(:push_registration).permit(:firebase_installation_id, :platform)
+    params.require(:push_registration).permit(
+      :firebase_installation_id,
+      :platform,
+      :device_model,
+      :os_version,
+      :app_version
+    )
   end
 end

--- a/app/javascript/controllers/native_push_subscription_controller.js
+++ b/app/javascript/controllers/native_push_subscription_controller.js
@@ -141,7 +141,8 @@ export default class extends PushSubscriptionUI {
       const registration = await savePushRegistration(
         this.registrationUrlValue,
         detail.firebaseInstallationId,
-        detail.platform
+        detail.platform,
+        detail
       )
       if (this.disconnected) return
 

--- a/app/javascript/controllers/push_subscription_ui.js
+++ b/app/javascript/controllers/push_subscription_ui.js
@@ -4,7 +4,7 @@ const BADGE_BASE_CLASSES = "inline-flex items-center px-2.5 py-0.5 rounded-full 
 const STATUS_TIMEOUT = 5000
 
 export default class extends Controller {
-  static targets = ["permissionBadge", "status", "subscriptionBadge", "toggle", "toggleKnob"]
+  static targets = ["checkingIndicator", "permissionBadge", "status", "subscriptionBadge", "toggle", "toggleKnob"]
 
   disconnect() {
     clearTimeout(this.statusTimeout)
@@ -18,6 +18,7 @@ export default class extends Controller {
 
   showSubscribed() {
     this._subscribed = true
+    this.finishChecking()
     this.setBusy(false)
     this.toggleTarget?.setAttribute("aria-checked", "true")
     this.toggleTarget?.classList.remove("bg-gray-200", "dark:bg-gray-600")
@@ -29,6 +30,7 @@ export default class extends Controller {
 
   showUnsubscribed() {
     this._subscribed = false
+    this.finishChecking()
     this.setBusy(false)
     this.toggleTarget?.setAttribute("aria-checked", "false")
     this.toggleTarget?.classList.remove("bg-blue-600")
@@ -41,6 +43,11 @@ export default class extends Controller {
   disableSubscription() {
     this.showUnsubscribed()
     this.setBusy(true)
+  }
+
+  finishChecking() {
+    this.element.setAttribute("aria-busy", "false")
+    if (this.hasCheckingIndicatorTarget) this.checkingIndicatorTarget.classList.add("hidden")
   }
 
   updatePermissionBadge(permission = "checking") {

--- a/app/javascript/controllers/web_push_subscription_controller.js
+++ b/app/javascript/controllers/web_push_subscription_controller.js
@@ -1,5 +1,9 @@
 import PushSubscriptionUI from "controllers/push_subscription_ui"
-import { removePushRegistration, savePushRegistration } from "push_registration_client"
+import {
+  removePushRegistration,
+  savePushRegistration,
+  webDeviceInformation
+} from "push_registration_client"
 
 export default class extends PushSubscriptionUI {
   static values = {
@@ -167,7 +171,13 @@ export default class extends PushSubscriptionUI {
     this.showRegistrationSuccess = false
 
     try {
-      const registration = await savePushRegistration(this.registrationUrlValue, firebaseInstallationId, "web")
+      const deviceInformation = await webDeviceInformation()
+      const registration = await savePushRegistration(
+        this.registrationUrlValue,
+        firebaseInstallationId,
+        "web",
+        deviceInformation
+      )
       if (this.disconnected) return
 
       this.firebaseInstallationId = firebaseInstallationId

--- a/app/javascript/push_registration_client.js
+++ b/app/javascript/push_registration_client.js
@@ -1,9 +1,15 @@
-export async function savePushRegistration(registrationUrl, firebaseInstallationId, platform) {
+export async function savePushRegistration(registrationUrl, firebaseInstallationId, platform, clientInformation = {}) {
   const response = await fetch(registrationUrl, {
     method: "POST",
     headers: requestHeaders(),
     body: JSON.stringify({
-      push_registration: { firebase_installation_id: firebaseInstallationId, platform }
+      push_registration: {
+        firebase_installation_id: firebaseInstallationId,
+        platform,
+        device_model: clientInformation.deviceModel,
+        os_version: clientInformation.osVersion,
+        app_version: clientInformation.appVersion
+      }
     })
   })
 
@@ -25,9 +31,57 @@ export async function removePushRegistration(destroyUrl) {
   }
 }
 
+export async function webDeviceInformation() {
+  const userAgentData = navigator.userAgentData
+
+  if (userAgentData?.getHighEntropyValues) {
+    const highEntropyValues = await userAgentData
+      .getHighEntropyValues(["fullVersionList"])
+      .catch(() => ({}))
+    const browser = preferredBrowser(highEntropyValues.fullVersionList || userAgentData.brands)
+
+    return {
+      deviceModel: normalizedBrowserName(browser?.brand),
+      osVersion: browser?.version
+    }
+  }
+
+  return legacyWebBrowserInformation(navigator.userAgent)
+}
+
 function requestHeaders() {
   return {
     "Content-Type": "application/json",
     "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content || ""
   }
+}
+
+function legacyWebBrowserInformation(userAgent) {
+  const browserPatterns = [
+    ["Edge", /Edg(?:A|iOS)?\/([\d.]+)/],
+    ["Opera", /(?:OPR|Opera)\/([\d.]+)/],
+    ["Chrome", /(?:Chrome|CriOS)\/([\d.]+)/],
+    ["Firefox", /(?:Firefox|FxiOS)\/([\d.]+)/],
+    ["Safari", /Version\/([\d.]+).*Safari/]
+  ]
+
+  for (const [browserName, pattern] of browserPatterns) {
+    const match = userAgent.match(pattern)
+    if (match) return { deviceModel: browserName, osVersion: match[1] }
+  }
+
+  return { deviceModel: "Web Browser", osVersion: null }
+}
+
+function preferredBrowser(browsers = []) {
+  return browsers.find(({ brand }) => !/Not.*Brand|Chromium/i.test(brand)) ||
+    browsers.find(({ brand }) => !/Not.*Brand/i.test(brand))
+}
+
+function normalizedBrowserName(browserName) {
+  if (!browserName) return "Web Browser"
+  if (/Microsoft Edge/i.test(browserName)) return "Edge"
+  if (/Google Chrome/i.test(browserName)) return "Chrome"
+
+  return browserName
 }

--- a/app/models/push_notification_log.rb
+++ b/app/models/push_notification_log.rb
@@ -1,0 +1,38 @@
+class PushNotificationLog < ApplicationRecord
+  STATUSES = %w[pending sent partially_failed failed no_targets].freeze
+
+  belongs_to :user
+
+  encrypts :title
+  encrypts :body
+  encrypts :url
+
+  validates :status, inclusion: { in: STATUSES }
+  validates :title, :body, :requested_at, presence: true
+  validates :target_count, :success_count, :failure_count,
+    numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  def complete!(targets:)
+    successful_count = targets.count { |target| target[:status] == "sent" }
+    failed_count = targets.size - successful_count
+
+    update!(
+      targets: targets,
+      target_count: targets.size,
+      success_count: successful_count,
+      failure_count: failed_count,
+      status: completed_status(targets.size, successful_count),
+      completed_at: Time.current
+    )
+  end
+
+  private
+
+  def completed_status(target_count, successful_count)
+    return "no_targets" if target_count.zero?
+    return "failed" if successful_count.zero?
+    return "sent" if successful_count == target_count
+
+    "partially_failed"
+  end
+end

--- a/app/models/push_registration.rb
+++ b/app/models/push_registration.rb
@@ -10,6 +10,7 @@ class PushRegistration < ApplicationRecord
   validates :platform, inclusion: { in: PLATFORMS }
   validates :platform, uniqueness: { scope: :session_id }
   validates :last_registered_at, presence: true
+  validates :device_model, :os_version, :app_version, length: { maximum: 255 }, allow_nil: true
   validate :session_matches_user
 
   def send_notification(title:, body:, url: nil, icon: nil)

--- a/app/models/push_registration.rb
+++ b/app/models/push_registration.rb
@@ -23,6 +23,16 @@ class PushRegistration < ApplicationRecord
     false
   end
 
+  def notification_target_snapshot
+    {
+      push_registration_id: id,
+      platform: platform,
+      device_model: device_model,
+      os_version: os_version,
+      app_version: app_version
+    }
+  end
+
   private
 
   def session_matches_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
 
   has_many :push_registrations, dependent: :destroy
+  has_many :push_notification_logs, dependent: :destroy
   has_many :user_plugins, dependent: :destroy
   has_many :push_notification_settings, dependent: :destroy
 
@@ -14,13 +15,30 @@ class User < ApplicationRecord
       return false if item_key && !push_notification_enabled?(plugin_name, item_key)
     end
 
-    sent_at_least_once = false
-    push_registrations.find_each do |registration|
-      if registration.send_notification(title: title, body: body, url: url)
-        sent_at_least_once = true
+    notification_log = push_notification_logs.create!(
+      title: title,
+      body: body,
+      url: url,
+      plugin_name: plugin_name,
+      item_key: item_key,
+      requested_at: Time.current
+    )
+    targets = push_registrations.find_each.map do |registration|
+      target = registration.notification_target_snapshot
+      sent = registration.send_notification(title: title, body: body, url: url)
+      status = if sent
+        "sent"
+      elsif registration.destroyed?
+        "invalid_registration"
+      else
+        "failed"
       end
+
+      target.merge(status: status)
     end
-    sent_at_least_once
+
+    notification_log.complete!(targets: targets)
+    notification_log.success_count.positive?
   end
 
   encrypts :email_address, deterministic: true

--- a/app/views/mypage/push_notifications/_native_subscription_card.html.erb
+++ b/app/views/mypage/push_notifications/_native_subscription_card.html.erb
@@ -1,4 +1,5 @@
 <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mb-6"
+     aria-busy="true"
      data-controller="native-push-subscription bridge--push-notification"
      data-native-push-subscription-destroy-urls-value="<%= @native_push_registrations.transform_values { |registration| mypage_push_registration_path(registration) }.to_json %>"
      data-native-push-subscription-registration-url-value="<%= mypage_push_registrations_path %>"

--- a/app/views/mypage/push_notifications/_subscription_card_content.html.erb
+++ b/app/views/mypage/push_notifications/_subscription_card_content.html.erb
@@ -25,6 +25,13 @@
         <p class="text-sm text-gray-600 dark:text-gray-400 mt-2">
           <%= t("settings.push_notifications.subscription_description") %>
         </p>
+        <div role="status"
+             aria-live="polite"
+             data-<%= controller_identifier %>-target="checkingIndicator"
+             class="mt-3 flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400">
+          <%= lucide_icon "loader-circle", class: "w-4 h-4 flex-shrink-0 animate-spin", aria: { hidden: true } %>
+          <span><%= t("settings.push_notifications.device_status_checking") %></span>
+        </div>
       </div>
     </div>
 

--- a/app/views/mypage/push_notifications/_web_subscription_card.html.erb
+++ b/app/views/mypage/push_notifications/_web_subscription_card.html.erb
@@ -1,4 +1,5 @@
 <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mb-6"
+     aria-busy="true"
      data-controller="web-push-subscription"
      data-web-push-subscription-configured-value="<%= @firebase_web_configured %>"
      data-web-push-subscription-firebase-config-value="<%= @firebase_web_config.to_json %>"

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,6 +1,7 @@
 {
   "name": "Console",
   "short_name": "Console",
+  "version": "<%= Rails.application.config.x.app_version %>",
   "description": "나만의 인생 기록을 위한 프라이빗 대시보드",
   "start_url": "/",
   "display": "standalone",

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.x.app_version = "1.0.0"
   # Web Push 알림 클릭 URL의 기준 주소
   config.x.web_push_base_url = "http://localhost:3000"
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.x.app_version = "1.0.0"
   # Web Push 알림 클릭 URL의 기준 주소
   config.x.web_push_base_url = "https://console.joungsik.com"
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,6 +4,7 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.x.app_version = "1.0.0"
   # Web Push 알림 클릭 URL의 기준 주소
   config.x.web_push_base_url = "https://example.com"
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/initializers/js_admin.rb
+++ b/config/initializers/js_admin.rb
@@ -1,6 +1,7 @@
 JSAdmin.configure do |config|
   config.include_models "User",
     "UserPlugin",
+    "PushNotificationLog",
     "PushNotificationSetting",
     "PushRegistration",
     "Todo::List",

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -364,6 +364,7 @@ ko:
       permission_granted: "권한 허용"
       permission_prompt: "권한 미결정"
       permission_denied: "권한 거부"
+      device_status_checking: "기기의 알림 권한과 구독 상태를 확인하고 있습니다."
       item_enabled: "알림이 활성화되었습니다."
       item_disabled: "알림이 비활성화되었습니다."
       item_not_found: "존재하지 않는 알림 항목입니다."

--- a/db/migrate/20260816000000_add_device_information_to_push_registrations.rb
+++ b/db/migrate/20260816000000_add_device_information_to_push_registrations.rb
@@ -1,0 +1,7 @@
+class AddDeviceInformationToPushRegistrations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :push_registrations, :device_model, :string
+    add_column :push_registrations, :os_version, :string
+    add_column :push_registrations, :app_version, :string
+  end
+end

--- a/db/migrate/20260816000001_create_push_notification_logs.rb
+++ b/db/migrate/20260816000001_create_push_notification_logs.rb
@@ -1,0 +1,24 @@
+class CreatePushNotificationLogs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :push_notification_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :status, null: false, default: "pending"
+      t.string :plugin_name
+      t.string :item_key
+      t.text :title, null: false
+      t.text :body, null: false
+      t.text :url
+      t.integer :target_count, null: false, default: 0
+      t.integer :success_count, null: false, default: 0
+      t.integer :failure_count, null: false, default: 0
+      t.json :targets, null: false, default: []
+      t.datetime :requested_at, null: false
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+
+    add_index :push_notification_logs, [ :user_id, :requested_at ]
+    add_index :push_notification_logs, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
+  create_table "push_notification_logs", force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.integer "failure_count", default: 0, null: false
+    t.string "item_key"
+    t.string "plugin_name"
+    t.datetime "requested_at", null: false
+    t.string "status", default: "pending", null: false
+    t.integer "success_count", default: 0, null: false
+    t.integer "target_count", default: 0, null: false
+    t.json "targets", default: [], null: false
+    t.text "title", null: false
+    t.datetime "updated_at", null: false
+    t.text "url"
+    t.integer "user_id", null: false
+    t.index ["status"], name: "index_push_notification_logs_on_status"
+    t.index ["user_id", "requested_at"], name: "index_push_notification_logs_on_user_id_and_requested_at"
+    t.index ["user_id"], name: "index_push_notification_logs_on_user_id"
+  end
+
   create_table "push_notification_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "enabled", default: true, null: false
@@ -72,6 +93,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_000000) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "push_notification_logs", "users"
   add_foreign_key "push_notification_settings", "users"
   add_foreign_key "push_registrations", "sessions"
   add_foreign_key "push_registrations", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_224257) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_000000) do
   create_table "push_notification_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "enabled", default: true, null: false
@@ -23,9 +23,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_224257) do
   end
 
   create_table "push_registrations", force: :cascade do |t|
+    t.string "app_version"
     t.datetime "created_at", null: false
+    t.string "device_model"
     t.text "firebase_installation_id", null: false
     t.datetime "last_registered_at", null: false
+    t.string "os_version"
     t.string "platform", null: false
     t.integer "session_id", null: false
     t.datetime "updated_at", null: false

--- a/test/integration/js_admin_test.rb
+++ b/test/integration/js_admin_test.rb
@@ -20,6 +20,7 @@ class JSAdminTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href='/admin/user']"
     assert_select "a[href='/admin/user_plugin']"
+    assert_select "a[href='/admin/push_notification_log']"
     assert_select "a[href='/admin/push_notification_setting']"
     assert_select "a[href='/admin/push_registration']"
     assert_select "a[href='/admin/todo--list']"
@@ -38,6 +39,7 @@ class JSAdminTest < ActionDispatch::IntegrationTest
   test "허용한 코어와 엔진 모델만 노출한다" do
     expected_model_names = [
       "Journal::Post",
+      "PushNotificationLog",
       "PushNotificationSetting",
       "PushRegistration",
       "Todo::Item",

--- a/test/integration/mypage/push_notifications_test.rb
+++ b/test/integration/mypage/push_notifications_test.rb
@@ -17,6 +17,8 @@ class Mypage::PushNotificationsTest < ActionDispatch::IntegrationTest
     assert_select "[data-web-push-subscription-firebase-config-value]", count: 1
     assert_select "[data-web-push-subscription-vapid-public-key-value]", count: 1
     assert_select "meta[name^='firebase-']", count: 0
+    assert_select "[data-controller='web-push-subscription'][aria-busy='true'] [data-web-push-subscription-target='checkingIndicator'][role='status']",
+      text: I18n.t("settings.push_notifications.device_status_checking")
 
     element = css_select("[data-web-push-subscription-status-messages-value]").first
     status_messages = JSON.parse(element["data-web-push-subscription-status-messages-value"])
@@ -64,6 +66,8 @@ class Mypage::PushNotificationsTest < ActionDispatch::IntegrationTest
     assert_select "[data-controller~='native-push-subscription'][data-controller~='bridge--push-notification']", count: 1
     assert_select "[data-controller='web-push-subscription']", count: 0
     assert_select "[data-web-push-subscription-firebase-config-value]", count: 0
+    assert_select "[data-controller~='native-push-subscription'][aria-busy='true'] [data-native-push-subscription-target='checkingIndicator'][role='status']",
+      text: I18n.t("settings.push_notifications.device_status_checking")
 
     element = css_select("[data-native-push-subscription-status-messages-value]").first
     status_messages = JSON.parse(element["data-native-push-subscription-status-messages-value"])

--- a/test/integration/mypage/push_registrations_test.rb
+++ b/test/integration/mypage/push_registrations_test.rb
@@ -7,7 +7,9 @@ class Mypage::PushRegistrationsTest < ActionDispatch::IntegrationTest
     @registration_params = {
       push_registration: {
         firebase_installation_id: "test-installation-id",
-        platform: "web"
+        platform: "web",
+        device_model: "Chrome",
+        os_version: "140.0.0.0"
       }
     }
   end
@@ -22,6 +24,29 @@ class Mypage::PushRegistrationsTest < ActionDispatch::IntegrationTest
     assert_equal mypage_push_registration_path(PushRegistration.last), response.parsed_body["destroy_url"]
     assert_equal @user, PushRegistration.last.user
     assert_equal Session.last, PushRegistration.last.session
+    assert_equal "1.0.0", PushRegistration.last.app_version
+    assert_equal "Chrome", PushRegistration.last.device_model
+    assert_equal "140.0.0.0", PushRegistration.last.os_version
+  end
+
+  test "네이티브 등록의 디바이스 정보를 저장할 수 있다" do
+    native_registration_params = {
+      push_registration: {
+        firebase_installation_id: "ios-installation-id",
+        platform: "ios",
+        device_model: "iPhone 17 Pro",
+        os_version: "iOS 20.0",
+        app_version: "1.0.0"
+      }
+    }
+
+    post mypage_push_registrations_url, params: native_registration_params, as: :json
+
+    assert_response :created
+    registration = PushRegistration.last
+    assert_equal "iPhone 17 Pro", registration.device_model
+    assert_equal "iOS 20.0", registration.os_version
+    assert_equal "1.0.0", registration.app_version
   end
 
   test "같은 firebase_installation_id를 다시 등록하면 최근 등록 시각을 갱신한다" do
@@ -35,6 +60,7 @@ class Mypage::PushRegistrationsTest < ActionDispatch::IntegrationTest
 
     assert_response :created
     assert_in_delta Time.current, registration.reload.last_registered_at, 2.seconds
+    assert_equal "1.0.0", registration.app_version
   end
 
   test "같은 세션과 플랫폼의 새 firebase_installation_id는 기존 등록을 교체한다" do

--- a/test/integration/pwa_manifest_test.rb
+++ b/test/integration/pwa_manifest_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class PwaManifestTest < ActionDispatch::IntegrationTest
+  test "현재 웹 앱 버전을 제공한다" do
+    get pwa_manifest_url(format: :json)
+
+    assert_response :success
+    assert_equal "1.0.0", response.parsed_body["version"]
+  end
+end

--- a/test/models/push_notification_log_test.rb
+++ b/test/models/push_notification_log_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class PushNotificationLogTest < ActiveSupport::TestCase
+  setup do
+    @notification_log = PushNotificationLog.create!(
+      user: users(:test_user),
+      title: "제목",
+      body: "내용",
+      requested_at: Time.current
+    )
+  end
+
+  test "모든 대상 발송 성공을 기록한다" do
+    targets = [
+      { push_registration_id: 1, platform: "ios", status: "sent" },
+      { push_registration_id: 2, platform: "web", status: "sent" }
+    ]
+
+    @notification_log.complete!(targets: targets)
+
+    assert_equal "sent", @notification_log.status
+    assert_equal 2, @notification_log.target_count
+    assert_equal 2, @notification_log.success_count
+    assert_equal 0, @notification_log.failure_count
+    assert_equal 2, @notification_log.targets.size
+    assert_not_nil @notification_log.completed_at
+  end
+
+  test "일부 대상 발송 실패를 기록한다" do
+    targets = [
+      { push_registration_id: 1, platform: "ios", status: "sent" },
+      { push_registration_id: 2, platform: "web", status: "failed" }
+    ]
+
+    @notification_log.complete!(targets: targets)
+
+    assert_equal "partially_failed", @notification_log.status
+    assert_equal 1, @notification_log.success_count
+    assert_equal 1, @notification_log.failure_count
+  end
+
+  test "발송 대상이 없음을 기록한다" do
+    @notification_log.complete!(targets: [])
+
+    assert_equal "no_targets", @notification_log.status
+    assert_equal 0, @notification_log.target_count
+  end
+end

--- a/test/models/push_registration_test.rb
+++ b/test/models/push_registration_test.rb
@@ -89,6 +89,15 @@ class PushRegistrationTest < ActiveSupport::TestCase
     end
   end
 
+  test "웹 푸시 대상 스냅샷은 브라우저를 디바이스 모델로 포함한다" do
+    @registration.update!(device_model: "Safari", os_version: "26.0")
+
+    snapshot = @registration.notification_target_snapshot
+
+    assert_equal "Safari", snapshot[:device_model]
+    assert_equal "26.0", snapshot[:os_version]
+  end
+
   private
 
   def stub_notification_sender(result: nil, error: nil)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -51,4 +51,79 @@ class UserTest < ActiveSupport::TestCase
     approaching = @user.approaching_deletion_plugins
     assert approaching.any? { |item| item[:plugin].name == :todos }
   end
+
+  test "푸시 발송 요청과 대상 디바이스별 성공 결과를 기록한다" do
+    registration = @user.push_registrations.create!(
+      session: @user.sessions.create!,
+      firebase_installation_id: "ios-installation-id",
+      platform: "ios",
+      device_model: "iPhone 17 Pro",
+      os_version: "iOS 20.0",
+      app_version: "1.2.3",
+      last_registered_at: Time.current
+    )
+
+    stub_notification_sender(result: true) do
+      assert @user.send_push_notification(
+        title: "할 일 알림",
+        body: "마감 시간이 다가옵니다.",
+        url: "/todos/1",
+        plugin_name: "todos",
+        item_key: "due_date_reminder"
+      )
+    end
+
+    notification_log = @user.push_notification_logs.last
+    target = notification_log.targets.first
+
+    assert_equal "sent", notification_log.status
+    assert_equal "할 일 알림", notification_log.title
+    assert_equal "todos", notification_log.plugin_name
+    assert_equal registration.id, target["push_registration_id"]
+    assert_equal "iPhone 17 Pro", target["device_model"]
+    assert_equal "sent", target["status"]
+  end
+
+  test "무효 등록 삭제 후에도 대상 디바이스 스냅샷을 기록한다" do
+    registration = @user.push_registrations.create!(
+      session: @user.sessions.create!,
+      firebase_installation_id: "invalid-installation-id",
+      platform: "ios",
+      app_version: "1.2.3",
+      last_registered_at: Time.current
+    )
+
+    stub_notification_sender(error: Fcm::InvalidRegistrationError.new("UNREGISTERED")) do
+      assert_not @user.send_push_notification(title: "제목", body: "내용")
+    end
+
+    notification_log = @user.push_notification_logs.last
+
+    assert_equal "failed", notification_log.status
+    assert_equal "invalid_registration", notification_log.targets.first["status"]
+    assert_equal registration.id, notification_log.targets.first["push_registration_id"]
+  end
+
+  test "등록 디바이스가 없으면 대상 없음으로 기록한다" do
+    assert_not @user.send_push_notification(title: "제목", body: "내용")
+
+    notification_log = @user.push_notification_logs.last
+
+    assert_equal "no_targets", notification_log.status
+    assert_equal 0, notification_log.target_count
+  end
+
+  private
+
+  def stub_notification_sender(result: nil, error: nil)
+    original = Fcm::NotificationSender.instance_method(:call)
+    Fcm::NotificationSender.define_method(:call) do |**|
+      raise error if error
+
+      result
+    end
+    yield
+  ensure
+    Fcm::NotificationSender.define_method(:call, original)
+  end
 end

--- a/test/system/hotwire_flows_test.rb
+++ b/test/system/hotwire_flows_test.rb
@@ -120,6 +120,7 @@ class HotwireFlowsTest < ApplicationSystemTestCase
     assert_selector "[data-web-push-subscription-target='permissionBadge']"
     assert_no_text I18n.t("settings.push_notifications.status_checking")
     assert_no_text I18n.t("settings.push_notifications.status.subscribed")
+    assert_no_text I18n.t("settings.push_notifications.device_status_checking")
 
     within("#notification_todos_due_date_reminder") { click_button }
     assert_current_path original_path


### PR DESCRIPTION
## 변경 내용

- Web과 Hotwire Native의 푸시 권한 및 구독 상태 확인 중 진행 표시를 추가했습니다.
- `PushRegistration`에 클라이언트 종류와 버전 정보를 저장하도록 확장했습니다.
  - Web: 브라우저명, 브라우저 버전, Web 앱 버전
  - Native: 기기 모델, OS 버전, 앱 버전
- Web 앱 버전을 환경별 `Rails.application.config.x.app_version`으로 관리하고 PWA 매니페스트에 노출했습니다.
- 사용자별 푸시 발송 요청을 `push_notification_logs`에 저장하도록 추가했습니다.
- 발송 대상 등록 정보와 성공·실패 결과를 스냅샷으로 보존합니다.
- 무효 FCM 등록이 삭제되어도 발송 당시 대상 정보가 이력에 남도록 했습니다.
- JSAdmin에서 푸시 발송 이력을 조회할 수 있도록 추가했습니다.

## 발송 이력

- 상태: `pending`, `sent`, `partially_failed`, `failed`, `no_targets`
- 대상 수, 성공 수, 실패 수 저장
- 메시지 제목, 본문, URL 암호화 저장
- 대상별 플랫폼, 클라이언트 정보, 발송 결과 저장
- FCM 토큰은 이력에 복사하지 않음

## 테스트

```bash
PARALLEL_WORKERS=1 bin/rails test
bin/rubocop --no-server --cache-root /private/tmp/console-rubocop-cache
bin/rails test test/system/hotwire_flows_test.rb:107
node --check app/javascript/push_registration_client.js
node --check app/javascript/controllers/web_push_subscription_controller.js
```

- Rails: 301 runs, 1,000 assertions, 0 failures, 0 errors
- RuboCop: 168 files inspected, no offenses
- 관련 브라우저 시스템 테스트 통과

## 관련 이슈

- [Redmine #356](https://redmine.joungsik.com/issues/356)
