### PR TITLE
[#361] iOS 날짜 입력창 너비 초과 수정

### DIFF
--- a/engines/todo/app/views/todo/lists/_item_fields.html.erb
+++ b/engines/todo/app/views/todo/lists/_item_fields.html.erb
@@ -18,7 +18,9 @@
 
   <div>
     <%= form.label :due_date, "마감일", class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" %>
-    <%= form.date_field :due_date, class: "w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" %>
+    <div class="w-full max-w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md px-3 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent">
+      <%= form.date_field :due_date, class: "block w-full min-w-0 max-w-full border-0 bg-transparent text-gray-900 dark:text-white rounded-none px-0 py-2 focus:outline-none focus:ring-0" %>
+    </div>
   </div>
 
   <div data-controller="recurrence">
@@ -34,7 +36,9 @@
 
       <div data-recurrence-target="endsOnField" class="<%= 'hidden' unless form.object&.recurrence.present? %>">
         <%= form.label :recurrence_ends_on, "반복 종료일", class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" %>
-        <%= form.date_field :recurrence_ends_on, class: "w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" %>
+        <div class="w-full max-w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md px-3 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent">
+          <%= form.date_field :recurrence_ends_on, class: "block w-full min-w-0 max-w-full border-0 bg-transparent text-gray-900 dark:text-white rounded-none px-0 py-2 focus:outline-none focus:ring-0" %>
+        </div>
       </div>
     </div>
   </div>

--- a/test/integration/todo/lists_test.rb
+++ b/test/integration/todo/lists_test.rb
@@ -50,6 +50,20 @@ class Todo::ListsTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "날짜 입력 필드는 카드 너비를 넘지 않도록 제한한다" do
+    @list.items.create!(
+      title: "반복 할 일",
+      due_date: Date.current,
+      recurrence: "daily",
+      recurrence_ends_on: Date.current + 1.month
+    )
+
+    get todo.edit_list_url(@list)
+
+    assert_response :success
+    assert_select "#items .item-fields div.w-full.max-w-full.px-3 > input[type='date'].w-full.min-w-0.max-w-full.px-0", count: 2
+  end
+
   test "제목만으로 목록을 생성할 수 있다" do
     assert_difference "Todo::List.count", 1 do
       post todo.lists_url, params: { list: { title: "새 목록" } }

--- a/test/system/todo_lists_test.rb
+++ b/test/system/todo_lists_test.rb
@@ -79,6 +79,52 @@ class TodoListsTest < ApplicationSystemTestCase
     assert_text "아직 할 일이 없습니다."
   end
 
+  test "모바일에서 날짜 입력은 할 일 카드 안에 표시된다" do
+    list = Todo::List.create!(title: "날짜 입력 목록", user_id: @user.id)
+    list.items.create!(
+      title: "반복 할 일",
+      due_date: Date.current,
+      recurrence: "daily",
+      recurrence_ends_on: Date.current + 1.month
+    )
+
+    use_mobile_viewport
+    visit todo.edit_list_url(list)
+
+    layout = page.evaluate_script(<<~JS)
+      (() => {
+        const card = document.querySelector(".item-fields").getBoundingClientRect();
+        const inputs = [...document.querySelectorAll(".item-fields input[type='date']")].map((input) => {
+          const bounds = input.getBoundingClientRect();
+          const inputStyle = getComputedStyle(input);
+          const wrapperStyle = getComputedStyle(input.parentElement);
+
+          return {
+            left: bounds.left,
+            right: bounds.right,
+            paddingLeft: parseFloat(inputStyle.paddingLeft),
+            paddingRight: parseFloat(inputStyle.paddingRight),
+            wrapperPaddingLeft: parseFloat(wrapperStyle.paddingLeft),
+            wrapperPaddingRight: parseFloat(wrapperStyle.paddingRight)
+          };
+        });
+
+        return { card: { left: card.left, right: card.right }, inputs };
+      })()
+    JS
+
+    assert_equal 2, layout["inputs"].size
+    layout["inputs"].each do |input|
+      assert_operator input["left"], :>=, layout["card"]["left"]
+      assert_operator input["right"], :<=, layout["card"]["right"]
+      assert_in_delta 0, input["paddingLeft"], 0.01
+      assert_in_delta 0, input["paddingRight"], 0.01
+      assert_operator input["wrapperPaddingLeft"], :>, 0
+      assert_operator input["wrapperPaddingRight"], :>, 0
+    end
+    assert_no_horizontal_overflow
+  end
+
   test "목록을 보관하고 복원할 수 있다" do
     list = Todo::List.create!(title: "보관 전환 목록", user_id: @user.id)
     visit todo.edit_list_url(list)


### PR DESCRIPTION
## 변경 사항

iOS WebKit이 `input[type="date"]`의 `width: 100%`와 좌우 padding을 잘못 계산해 Todo 카드 밖으로 넘치던 문제를 수정했습니다.
마감일과 반복 종료일 input의 좌우 padding을 wrapper로 옮기고 `min-w-0`, `max-w-full`을 적용해 native date picker와 다른 브라우저의 레이아웃을 유지했습니다.
통합 테스트로 두 날짜 필드의 CSS 계약을, 모바일 시스템 테스트로 카드 경계·계산된 padding·문서 수평 overflow를 검증했습니다.
`bin/rails test test/integration/todo/lists_test.rb`와 `bin/rails test:system test/system/todo_lists_test.rb test/system/responsive_pages_test.rb`가 통과했으며 iOS 실기기에서도 정상 동작을 확인했습니다.