### PR TITLE
[#362] 홈 대시보드 공지사항 및 상세 화면 추가

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "solid_queue"
 gem "mission_control-jobs"
 # Generic admin UI for Active Record models
 gem "js_admin"
+# Rich text editor for Action Text
+gem "lexxy", "~> 0.9.30"
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,8 @@ GEM
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.6)
+    lexxy (0.9.30)
+      rails (>= 8.0.2)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.2)
@@ -421,6 +423,7 @@ DEPENDENCIES
   importmap-rails
   journal!
   js_admin
+  lexxy (~> 0.9.30)
   lucide-rails
   mission_control-jobs
   propshaft

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -28,6 +28,32 @@
 }
 
 @layer components {
+  .lexxy-content {
+    --lexxy-color-ink: var(--color-gray-700);
+    --lexxy-color-ink-medium: var(--color-gray-600);
+    --lexxy-color-ink-lighter: var(--color-gray-300);
+    --lexxy-color-ink-lightest: var(--color-gray-100);
+    --lexxy-color-link: var(--color-blue-600);
+    font-size: 0.875rem;
+    line-height: 1.625;
+
+    @variant dark {
+      --lexxy-color-ink: var(--color-gray-200);
+      --lexxy-color-ink-medium: var(--color-gray-400);
+      --lexxy-color-ink-lighter: var(--color-gray-600);
+      --lexxy-color-ink-lightest: var(--color-gray-700);
+      --lexxy-color-link: var(--color-blue-400);
+      --lexxy-color-code-token-att: #ff7b72;
+      --lexxy-color-code-token-comment: #8b949e;
+      --lexxy-color-code-token-function: #d2a8ff;
+      --lexxy-color-code-token-operator: #ff7b72;
+      --lexxy-color-code-token-property: #79c0ff;
+      --lexxy-color-code-token-punctuation: #f0f6fc;
+      --lexxy-color-code-token-selector: #7ee787;
+      --lexxy-color-code-token-variable: #ffa657;
+    }
+  }
+
   .legal-content {
     font-size: 0.875rem;
     line-height: 1.625;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,6 +13,7 @@ class HomeController < ApplicationController
   private
 
   def load_dashboard
+    @notices = Notice.visible_on.with_rich_text_body
     active_plugins = current_user.enabled_plugins & PluginRegistry.dashboard_plugins
 
     @dashboard_components = active_plugins.filter_map do |plugin|

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,0 +1,5 @@
+class NoticesController < ApplicationController
+  def show
+    @notice = Notice.visible_on.find(params[:id])
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
+import "lexxy"
 import "service_worker_registration"

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,0 +1,22 @@
+class Notice < ApplicationRecord
+  has_rich_text :body
+
+  validates :title, :published_on, :position, presence: true
+  validates :position, numericality: { only_integer: true }
+  validate :expires_on_cannot_precede_published_on
+
+  scope :visible_on, ->(date = Date.current) {
+    where(published_on: ..date)
+      .where(expires_on: nil)
+      .or(where(published_on: ..date, expires_on: date..))
+      .order(:position, :id)
+  }
+
+  private
+
+  def expires_on_cannot_precede_published_on
+    return if published_on.blank? || expires_on.blank? || expires_on >= published_on
+
+    errors.add(:expires_on, :before_published_on)
+  end
+end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,8 +7,19 @@
     <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">전체 현황을 한눈에 확인하세요.</p>
   </div>
 
+  <% if @notices.present? %>
+    <section id="dashboard-notices" class="mb-6" aria-labelledby="dashboard-notices-heading">
+      <h2 id="dashboard-notices-heading" class="text-xl font-semibold text-gray-900 dark:text-white">
+        <%= t("home.notices.title") %>
+      </h2>
+      <div class="mt-3 space-y-3">
+        <%= render @notices %>
+      </div>
+    </section>
+  <% end %>
+
   <% if @approaching_deletion_plugins.present? %>
-    <div class="mb-4 space-y-2">
+    <div id="dashboard-plugin-deletion-warnings" class="mb-4 space-y-2">
       <% @approaching_deletion_plugins.each do |item| %>
         <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div class="flex items-start sm:items-center">
@@ -27,7 +38,7 @@
   <% end %>
 
   <% if @dashboard_components.present? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 lg:gap-6">
+    <div id="dashboard-widgets" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 lg:gap-6">
       <% @dashboard_components.each do |component| %>
         <%= render partial: component.partial_path, locals: component.locals %>
       <% end %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -28,6 +28,6 @@
 <link rel="icon" href="/icon.png" type="image/png">
 <link rel="apple-touch-icon" href="/icon.png">
 
-<%= stylesheet_link_tag "application", "tailwind", "data-turbo-track": "reload" %>
+<%= stylesheet_link_tag "application", "lexxy", "tailwind", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "hotwire_native", "data-turbo-track": "reload" if hotwire_native_app? %>
 <%= javascript_importmap_tags %>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="lexxy-content">
+  <%= yield -%>
+</div>

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -1,0 +1,10 @@
+<article id="<%= dom_id(notice) %>">
+  <%= link_to notice_path(notice),
+      class: "group flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 shadow-sm transition-colors duration-200 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-blue-800 dark:bg-blue-900/20 dark:hover:bg-blue-900/30 dark:focus:ring-offset-gray-900 sm:p-5" do %>
+    <%= lucide_icon "megaphone", class: "h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" %>
+    <h3 class="min-w-0 flex-1 truncate text-base font-semibold text-gray-900 dark:text-white">
+      <%= notice.title %>
+    </h3>
+    <%= lucide_icon "chevron-right", class: "h-5 w-5 flex-shrink-0 text-blue-500 transition-transform duration-200 group-hover:translate-x-0.5 dark:text-blue-400" %>
+  <% end %>
+</article>

--- a/app/views/notices/show.html.erb
+++ b/app/views/notices/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:title) { @notice.title } %>
+
+<div class="mx-auto w-full max-w-4xl">
+  <div class="mb-6" data-native-page-navigation>
+    <%= link_to root_path,
+        class: "inline-flex items-center gap-1 text-sm text-gray-600 transition-colors duration-200 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" do %>
+      <%= lucide_icon "arrow-left", class: "h-4 w-4" %>
+      <%= t("home.notices.back_to_dashboard") %>
+    <% end %>
+  </div>
+
+  <article class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white sm:text-3xl"
+        data-native-page-title>
+      <%= @notice.title %>
+    </h1>
+    <div class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
+      <%= @notice.body %>
+    </div>
+  </article>
+</div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -13,5 +13,7 @@ pin "@hotwired/hotwire-native-bridge", to: "@hotwired--hotwire-native-bridge.js"
 pin "js_admin", to: "js_admin/application.js", preload: true
 pin "js_admin/controllers/theme_controller", to: "js_admin/controllers/theme_controller.js", preload: true
 pin "js_admin/controllers/flash_controller", to: "js_admin/controllers/flash_controller.js", preload: true
+pin "lexxy", to: "lexxy.js"
+pin "@rails/activestorage", to: "activestorage.esm.js"
 pin "firebase/app", to: "https://www.gstatic.com/firebasejs/12.17.1/firebase-app.js" # @12.17.1
 pin "firebase/messaging", to: "https://www.gstatic.com/firebasejs/12.17.1/firebase-messaging.js" # @12.17.1

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -171,6 +171,7 @@ ko:
 
   activerecord:
     models:
+      notice: "공지사항"
       user: "사용자"
       link: "링크"
       collection: "컬렉션"
@@ -178,6 +179,12 @@ ko:
       todo: "할 일"
       journal/post: "포스트"
     attributes:
+      notice:
+        title: "제목"
+        body: "내용"
+        published_on: "게시일"
+        expires_on: "만료일"
+        position: "노출 순서"
       user:
         name: "이름"
         email_address: "이메일"
@@ -204,6 +211,10 @@ ko:
         body: "내용"
     errors:
       models:
+        notice:
+          attributes:
+            expires_on:
+              before_published_on: "은 게시일보다 빠를 수 없습니다."
         user:
           attributes:
             password:
@@ -221,6 +232,11 @@ ko:
             url:
               invalid_url_format: "올바른 URL 형식이 아닙니다. http:// 또는 https://로 시작해야 합니다."
     enums:
+
+  home:
+    notices:
+      title: "공지사항"
+      back_to_dashboard: "대시보드"
 
   actions:
     show: "보기"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "home#index"
 
+  resources :notices, only: :show
   resource :session, only: %i[new create destroy]
   resource :registration, only: %i[new create] do
     get :verify_pending, on: :collection

--- a/db/migrate/20260819000000_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260819000000_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,38 @@
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string :key, null: false
+      t.string :filename, null: false
+      t.string :content_type
+      t.text :metadata
+      t.string :service_name, null: false
+      t.bigint :byte_size, null: false
+      t.string :checksum
+      t.datetime :created_at, precision: 6, null: false
+
+      t.index :key, unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string :name, null: false
+      t.references :record, null: false, polymorphic: true, index: false
+      t.references :blob, null: false
+      t.datetime :created_at, precision: 6, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ],
+        name: :index_active_storage_attachments_uniqueness,
+        unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ],
+        name: :index_active_storage_variant_records_uniqueness,
+        unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20260819000001_create_action_text_tables.action_text.rb
+++ b/db/migrate/20260819000001_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string :name, null: false
+      t.text :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ],
+        name: :index_action_text_rich_texts_uniqueness,
+        unique: true
+    end
+  end
+end

--- a/db/migrate/20260819000002_create_notices.rb
+++ b/db/migrate/20260819000002_create_notices.rb
@@ -1,0 +1,11 @@
+class CreateNotices < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notices do |t|
+      t.string :title, null: false
+      t.date :published_on, null: false
+      t.date :expires_on
+      t.integer :position, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,54 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_19_000002) do
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.integer "record_id", null: false
+    t.string "record_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.integer "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "notices", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.date "expires_on"
+    t.integer "position", null: false
+    t.date "published_on", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "push_notification_logs", force: :cascade do |t|
     t.text "body", null: false
     t.datetime "completed_at"
@@ -93,6 +140,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_000001) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "push_notification_logs", "users"
   add_foreign_key "push_notification_settings", "users"
   add_foreign_key "push_registrations", "sessions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,4 +51,40 @@ end
 
 puts "Journal: #{Journal::Post.count} posts"
 
+if Rails.env.development?
+  [
+    {
+      title: "Console 공지사항 기능 안내",
+      published_on: Date.new(2020, 1, 1),
+      expires_on: nil,
+      position: 10,
+      body: <<~HTML
+        <p><strong>Console 공지사항 기능을 확인해 보세요.</strong></p>
+        <p>공지 본문에는 <a href="https://lexxy.dev/">링크와 다양한 서식</a>을 사용할 수 있습니다.</p>
+      HTML
+    },
+    {
+      title: "개발 환경 점검 안내",
+      published_on: Date.new(2020, 1, 1),
+      expires_on: Date.new(2099, 12, 31),
+      position: 20,
+      body: <<~HTML
+        <p><strong>개발 환경 점검 안내</strong></p>
+        <ul>
+          <li>라이트 모드와 다크 모드의 콘텐츠 스타일을 확인하세요.</li>
+          <li>여러 공지가 노출 순서대로 표시되는지 확인하세요.</li>
+        </ul>
+      HTML
+    }
+  ].each do |attributes|
+    body = attributes.delete(:body)
+    notice = Notice.find_or_initialize_by(attributes.except(:title))
+    notice.title = attributes[:title]
+    notice.body = body
+    notice.save!
+  end
+
+  puts "Notice: #{Notice.count} notices"
+end
+
 puts "Seed 완료!"

--- a/test/integration/home_test.rb
+++ b/test/integration/home_test.rb
@@ -50,4 +50,69 @@ class HomeTest < ActionDispatch::IntegrationTest
     assert_select "a[href='#{todo.root_path}']", "전체보기"
     assert_select "a[href='#{posts.root_path}']", { text: "전체보기", count: 0 }
   end
+
+  test "대시보드에는 노출 기간인 공지만 순서대로 표시된다" do
+    second = create_notice(title: "두 번째 공지", body: "두 번째 내용", position: 20)
+    first = create_notice(title: "첫 번째 공지", body: "첫 번째 내용", position: 10)
+    create_notice(title: "게시 전 공지", published_on: Date.current.tomorrow)
+    create_notice(
+      title: "만료된 공지",
+      published_on: Date.current - 2.days,
+      expires_on: Date.current.yesterday
+    )
+
+    sign_in_as @user
+    get root_url
+
+    assert_select "#dashboard-notices article", count: 2
+    assert_select "##{dom_id(first)} a[href='#{notice_path(first)}']", "첫 번째 공지"
+    assert_select "##{dom_id(second)} a[href='#{notice_path(second)}']", "두 번째 공지"
+    assert_operator response.body.index(dom_id(first)), :<, response.body.index(dom_id(second))
+    assert_no_match "첫 번째 내용", response.body
+    assert_no_match "두 번째 내용", response.body
+    assert_no_match "게시 전 공지", response.body
+    assert_no_match "만료된 공지", response.body
+  end
+
+  test "공지는 삭제 예정 배너와 대시보드 위젯보다 먼저 표시된다" do
+    create_notice(title: "상단 공지")
+    UserPlugin.create!(
+      user: @user,
+      plugin_name: "posts",
+      enabled: false,
+      disabled_at: 25.days.ago
+    )
+
+    sign_in_as @user
+    get root_url
+
+    notice_position = response.body.index("dashboard-notices")
+    warning_position = response.body.index("dashboard-plugin-deletion-warnings")
+    widget_position = response.body.index("dashboard-widgets")
+
+    assert_operator notice_position, :<, warning_position
+    assert_operator warning_position, :<, widget_position
+  end
+
+  test "노출 대상 공지가 없으면 공지 영역을 렌더링하지 않는다" do
+    sign_in_as @user
+    get root_url
+
+    assert_select "#dashboard-notices", count: 0
+  end
+
+  test "비인증 랜딩 페이지에는 공지를 표시하지 않는다" do
+    create_notice(title: "로그인 전에는 보이지 않는 공지")
+
+    get root_url
+
+    assert_select "#dashboard-notices", count: 0
+    assert_no_match "로그인 전에는 보이지 않는 공지", response.body
+  end
+
+  private
+
+  def create_notice(title:, body: "공지 내용", published_on: Date.current, expires_on: nil, position: 1)
+    Notice.create!(title:, body:, published_on:, expires_on:, position:)
+  end
 end

--- a/test/integration/hotwire_native_page_contract_test.rb
+++ b/test/integration/hotwire_native_page_contract_test.rb
@@ -8,6 +8,7 @@ class HotwireNativePageContractTest < ActionDispatch::IntegrationTest
     @user = users(:test_user)
     @post = Journal::Post.create!(body: "Native 페이지 계약", user_id: @user.id)
     @list = Todo::List.create!(title: "Native 페이지 계약", user_id: @user.id)
+    @notice = Notice.create!(title: "Native 공지", published_on: Date.current, position: 1)
   end
 
   test "공개 페이지가 Native 제목과 상단 여백 계약을 지킨다" do
@@ -30,6 +31,7 @@ class HotwireNativePageContractTest < ActionDispatch::IntegrationTest
 
     pages = {
       root_url => "대시보드",
+      notice_url(@notice) => @notice.title,
       mypage_user_url => I18n.t("settings.mypage.title"),
       mypage_plugins_url => I18n.t("settings.plugins.title"),
       mypage_push_notifications_url => I18n.t("settings.push_notifications.page_title"),

--- a/test/integration/notices_test.rb
+++ b/test/integration/notices_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class NoticesTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:test_user)
+    @notice = Notice.create!(
+      title: "중요 공지",
+      body: <<~HTML,
+        <p><strong>공지 내용</strong></p>
+        <ul><li><a href="https://example.com">자세히 보기</a></li></ul>
+        <script>window.unsafeNotice = true</script>
+      HTML
+      published_on: Date.current,
+      position: 1
+    )
+  end
+
+  test "인증 사용자는 노출 중인 공지 상세를 조회할 수 있다" do
+    sign_in_as @user
+
+    get notice_url(@notice)
+
+    assert_response :success
+    assert_select "title", @notice.title
+    assert_select "h1[data-native-page-title]", @notice.title
+    assert_select ".lexxy-content strong", "공지 내용"
+    assert_select ".lexxy-content ul li a[href='https://example.com']", "자세히 보기"
+    assert_select "article script", count: 0
+  end
+
+  test "비인증 사용자는 공지 상세에 접근할 수 없다" do
+    get notice_url(@notice)
+
+    assert_redirected_to new_session_path
+  end
+
+  test "Native 비인증 요청은 공지 상세 URL을 보존하고 unauthorized를 반환한다" do
+    get notice_url(@notice), headers: { "User-Agent" => "Console Hotwire Native iOS" }
+
+    assert_response :unauthorized
+    post session_url, params: { email_address: @user.email_address, password: "password123" }
+    assert_redirected_to notice_url(@notice)
+  end
+
+  test "게시 전 공지에는 직접 접근할 수 없다" do
+    notice = Notice.create!(title: "게시 전", published_on: Date.current.tomorrow, position: 1)
+    sign_in_as @user
+
+    get notice_url(notice)
+
+    assert_response :not_found
+  end
+
+  test "만료된 공지에는 직접 접근할 수 없다" do
+    notice = Notice.create!(
+      title: "만료됨",
+      published_on: Date.current - 2.days,
+      expires_on: Date.current.yesterday,
+      position: 1
+    )
+    sign_in_as @user
+
+    get notice_url(notice)
+
+    assert_response :not_found
+  end
+end

--- a/test/models/notice_test.rb
+++ b/test/models/notice_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class NoticeTest < ActiveSupport::TestCase
+  setup do
+    @today = Date.new(2026, 8, 19)
+  end
+
+  test "제목과 게시일과 노출 순서는 필수다" do
+    notice = Notice.new
+
+    assert_not notice.valid?
+    assert_includes notice.errors[:title], "입력해주세요."
+    assert_includes notice.errors[:published_on], "입력해주세요."
+    assert_includes notice.errors[:position], "입력해주세요."
+  end
+
+  test "노출 순서는 정수만 허용한다" do
+    notice = Notice.new(title: "공지", published_on: @today, position: 1.5)
+
+    assert_not notice.valid?
+    assert_predicate notice.errors[:position], :present?
+  end
+
+  test "만료일이 없으면 유효하다" do
+    notice = Notice.new(title: "공지", published_on: @today, expires_on: nil, position: 1)
+
+    assert_predicate notice, :valid?
+  end
+
+  test "만료일은 게시일보다 빠를 수 없다" do
+    notice = Notice.new(title: "공지", published_on: @today, expires_on: @today.yesterday, position: 1)
+
+    assert_not notice.valid?
+    assert_includes notice.errors[:expires_on], "은 게시일보다 빠를 수 없습니다."
+  end
+
+  test "게시일과 만료일이 같으면 유효하다" do
+    notice = Notice.new(title: "공지", published_on: @today, expires_on: @today, position: 1)
+
+    assert_predicate notice, :valid?
+  end
+
+  test "visible_on은 게시일 전과 만료일 후 공지를 제외한다" do
+    future = create_notice(published_on: @today.tomorrow)
+    expired = create_notice(published_on: @today - 2.days, expires_on: @today.yesterday)
+    visible = create_notice(published_on: @today.yesterday, expires_on: @today.tomorrow)
+
+    notices = Notice.visible_on(@today)
+
+    assert_includes notices, visible
+    assert_not_includes notices, future
+    assert_not_includes notices, expired
+  end
+
+  test "visible_on은 게시일과 만료일 당일을 포함한다" do
+    published_today = create_notice(published_on: @today)
+    expires_today = create_notice(published_on: @today.yesterday, expires_on: @today)
+
+    notices = Notice.visible_on(@today)
+
+    assert_includes notices, published_today
+    assert_includes notices, expires_today
+  end
+
+  test "visible_on은 만료일이 없는 공지를 계속 포함한다" do
+    notice = create_notice(published_on: @today.yesterday, expires_on: nil)
+
+    assert_includes Notice.visible_on(@today + 10.years), notice
+  end
+
+  test "visible_on은 노출 순서와 id 순서로 안정적으로 정렬한다" do
+    second = create_notice(position: 20)
+    first_tie = create_notice(position: 10)
+    second_tie = create_notice(position: 10)
+    first = create_notice(position: 5)
+
+    assert_equal [ first, first_tie, second_tie, second ], Notice.visible_on(@today).to_a
+  end
+
+  private
+
+  def create_notice(published_on: @today.yesterday, expires_on: nil, position: 1)
+    Notice.create!(title: "공지", published_on:, expires_on:, position:)
+  end
+end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -87,4 +87,22 @@ class HomeSystemTest < ApplicationSystemTestCase
 
     assert_current_path todo.root_path
   end
+
+  test "공지 제목을 선택하면 상세 내용을 볼 수 있다" do
+    notice = Notice.create!(
+      title: "시스템 테스트 공지",
+      body: "상세 공지 내용",
+      published_on: Date.current,
+      position: 1
+    )
+    sign_in_as @user
+
+    within "#dashboard-notices" do
+      click_link notice.title
+    end
+
+    assert_current_path notice_path(notice)
+    assert_selector "h1", text: notice.title
+    assert_text "상세 공지 내용"
+  end
 end


### PR DESCRIPTION
## 요약

- 로그인 사용자의 홈 대시보드에 게시 기간과 순서에 맞는 공지 제목을 표시하고 상세 화면에서 내용을 확인하도록 구현했습니다.
- Lexxy, Action Text, Active Storage를 도입해 rich text 본문과 다크 모드 렌더링을 지원하며 개발용 seed를 추가했습니다.
- 게시 전·만료 공지의 직접 접근을 차단하고 웹 및 Hotwire Native 인증·페이지 계약을 보강했습니다.

## 검증

- `bin/rails test` (320 tests, 1080 assertions)
- 관련 시스템 테스트 10건, `bin/rubocop`, `bin/rails zeitwerk:check`, 자산 precompile 통과