### PR TITLE
[#364] Hotwire Native 마이페이지 중복 설정 링크 숨김

### DIFF
--- a/app/views/mypage/users/show.html.erb
+++ b/app/views/mypage/users/show.html.erb
@@ -165,44 +165,46 @@
     </div>
   </div>
 
-  <%= link_to mypage_plugins_path,
-      class: "block bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mb-6 hover:shadow-md transition-shadow duration-200 overflow-hidden" do %>
-    <div class="p-6">
-      <div class="flex items-center justify-between">
-        <div class="flex items-start sm:items-center min-w-0">
-          <%= lucide_icon "puzzle", class: "w-6 h-6 text-blue-600 dark:text-blue-400 mr-3 flex-shrink-0 mt-0.5 sm:mt-0" %>
-          <div class="min-w-0">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-              <%= t('settings.plugins.title') %>
-            </h2>
-            <p class="text-sm text-gray-600 dark:text-gray-400">
-              <%= t('settings.plugins.short_description') %>
-            </p>
+  <% unless hotwire_native_app? %>
+    <%= link_to mypage_plugins_path,
+        class: "block bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mb-6 hover:shadow-md transition-shadow duration-200 overflow-hidden" do %>
+      <div class="p-6">
+        <div class="flex items-center justify-between">
+          <div class="flex items-start sm:items-center min-w-0">
+            <%= lucide_icon "puzzle", class: "w-6 h-6 text-blue-600 dark:text-blue-400 mr-3 flex-shrink-0 mt-0.5 sm:mt-0" %>
+            <div class="min-w-0">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                <%= t('settings.plugins.title') %>
+              </h2>
+              <p class="text-sm text-gray-600 dark:text-gray-400">
+                <%= t('settings.plugins.short_description') %>
+              </p>
+            </div>
           </div>
+          <%= lucide_icon "chevron-right", class: "w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" %>
         </div>
-        <%= lucide_icon "chevron-right", class: "w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
 
-  <%= link_to mypage_push_notifications_path,
-      class: "block bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden" do %>
-    <div class="p-6">
-      <div class="flex items-center justify-between">
-        <div class="flex items-start sm:items-center min-w-0">
-          <%= lucide_icon "bell", class: "w-6 h-6 text-blue-600 dark:text-blue-400 mr-3 flex-shrink-0 mt-0.5 sm:mt-0" %>
-          <div class="min-w-0">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-              <%= t('settings.push_notifications.title') %>
-            </h2>
-            <p class="text-sm text-gray-600 dark:text-gray-400">
-              <%= t('settings.push_notifications.short_description') %>
-            </p>
+    <%= link_to mypage_push_notifications_path,
+        class: "block bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden" do %>
+      <div class="p-6">
+        <div class="flex items-center justify-between">
+          <div class="flex items-start sm:items-center min-w-0">
+            <%= lucide_icon "bell", class: "w-6 h-6 text-blue-600 dark:text-blue-400 mr-3 flex-shrink-0 mt-0.5 sm:mt-0" %>
+            <div class="min-w-0">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                <%= t('settings.push_notifications.title') %>
+              </h2>
+              <p class="text-sm text-gray-600 dark:text-gray-400">
+                <%= t('settings.push_notifications.short_description') %>
+              </p>
+            </div>
           </div>
+          <%= lucide_icon "chevron-right", class: "w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" %>
         </div>
-        <%= lucide_icon "chevron-right", class: "w-5 h-5 text-gray-400 dark:text-gray-500 flex-shrink-0" %>
       </div>
-    </div>
+    <% end %>
   <% end %>
 
   <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm mt-6">

--- a/test/integration/mypage/users_test.rb
+++ b/test/integration/mypage/users_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Mypage::UsersTest < ActionDispatch::IntegrationTest
+  NATIVE_HEADERS = { "User-Agent" => "Console Hotwire Native iOS" }.freeze
+
   setup do
     @user = users(:test_user)
     sign_in_as @user
@@ -14,6 +16,20 @@ class Mypage::UsersTest < ActionDispatch::IntegrationTest
     assert_select "body[data-theme-preference='system']"
     assert_select "input[name='theme[value]']", count: 3
     assert_select "form[data-action~='turbo:submit-end->theme#submitEnd']"
+    assert_select "a[href='#{mypage_plugins_path}']", count: 1
+    assert_select "a[href='#{mypage_push_notifications_path}']", count: 1
+  end
+
+  test "Native 마이페이지에는 중복 설정 링크만 표시되지 않는다" do
+    get mypage_user_url, headers: NATIVE_HEADERS
+
+    assert_response :success
+    assert_select "a[href='#{mypage_plugins_path}']", count: 0
+    assert_select "a[href='#{mypage_push_notifications_path}']", count: 0
+    assert_select "form[action='#{mypage_theme_path}']", count: 1
+    assert_select "form[action='#{mypage_user_path}']", count: 1
+    assert_select "dl", text: /#{Regexp.escape(@user.name)}/
+    assert_select "a[href='#{session_path}'][data-turbo-method='delete']", count: 1
   end
 
   test "테마를 변경할 수 있다" do

--- a/test/system/hotwire_native_layout_test.rb
+++ b/test/system/hotwire_native_layout_test.rb
@@ -26,6 +26,27 @@ class HotwireNativeLayoutTest < ApplicationSystemTestCase
     end
   end
 
+  test "Native 마이페이지는 중복 설정 링크와 불필요한 카드 여백이 없다" do
+    use_mobile_viewport
+    sign_in_as users(:test_user)
+    original_user_agent = page.evaluate_script("navigator.userAgent")
+    set_user_agent(NATIVE_USER_AGENT)
+
+    begin
+      visit mypage_user_url
+
+      assert_no_selector "a[href='#{mypage_plugins_path}']"
+      assert_no_selector "a[href='#{mypage_push_notifications_path}']"
+      assert_selector "form[action='#{mypage_theme_path}']"
+      assert_selector "form[action='#{mypage_user_path}']"
+      assert_selector "a[href='#{session_path}'][data-turbo-method='delete']"
+      assert_in_delta 24, password_and_logout_card_gap, 1
+      assert_no_horizontal_overflow
+    ensure
+      set_user_agent(original_user_agent)
+    end
+  end
+
   private
 
   def set_user_agent(user_agent)
@@ -69,5 +90,16 @@ class HotwireNativeLayoutTest < ApplicationSystemTestCase
 
     assert_operator dimensions["documentHeight"], :<=, dimensions["viewportHeight"] + 1,
       "#{path}에 불필요한 Native 문서 스크롤이 없어야 합니다"
+  end
+
+  def password_and_logout_card_gap
+    page.evaluate_script(<<~JS)
+      (() => {
+        const passwordCard = document.querySelector("form[action='#{mypage_user_path}']").closest(".shadow-sm")
+        const logoutCard = document.querySelector("a[href='#{session_path}'][data-turbo-method='delete']").closest(".shadow-sm")
+
+        return logoutCard.getBoundingClientRect().top - passwordCard.getBoundingClientRect().bottom
+      })()
+    JS
   end
 end


### PR DESCRIPTION
## 변경 사항

Hotwire Native 마이페이지에서 별도 탭과 중복되는 플러그인 설정 및 푸시 알림 설정 카드를 서버 렌더링 단계에서 숨겼습니다.
일반 웹에서는 두 카드를 유지하고 Native의 나머지 마이페이지 기능과 설정 화면 직접 접근에는 영향을 주지 않습니다.
웹·Native 렌더링 분기와 모바일 카드 간격 및 수평 overflow를 integration/system 테스트로 검증했습니다.

## 검증

- `bin/rails test` — 321 tests, 1,090 assertions
- 관련 integration tests — 29 tests, 251 assertions
- 관련 system tests — 8 tests, 598 assertions